### PR TITLE
Update thaumicaugmentation.cfg

### DIFF
--- a/Client/overrides/config/thaumicaugmentation.cfg
+++ b/Client/overrides/config/thaumicaugmentation.cfg
@@ -351,10 +351,8 @@ world {
         -1=15
         1=10
         7=5
-        17=5
         20=5
-        111=5
-        66=5
+        -23=5
      >
 
     # The chance for a fracture to generate in a chunk in the Emptiness dimension.


### PR DESCRIPTION
Removed space-gated dimensions (Atum and Erebus) from Fracture list and added Midnight to Fracture list. also removed Lost Cities from the list, as it is not present in the pack.