### PR TITLE
Swap target version of Ancient Spellcraft to 1.1.3

### DIFF
--- a/Client/manifest.json
+++ b/Client/manifest.json
@@ -961,7 +961,7 @@
     },
     {
       "projectID": 358124,
-      "fileID": 3207730,
+      "fileID": 3238582,
       "required": true
     },
     {


### PR DESCRIPTION
Switches Ancient Spellcraft's target fileID in the manifest from 1.1.2 version to 1.1.3 version, which is very new (2 days old), fixes several bugs with the mod.