### PR TITLE
Buff Impulse Cannon significantly

### DIFF
--- a/Client/overrides/config/thaumicaugmentation.cfg
+++ b/Client/overrides/config/thaumicaugmentation.cfg
@@ -183,7 +183,7 @@ gameplay {
             # The beam does not reset the damage cooldowns of entities damaged by it,
             # so while this damage can theoretically be seen per tick, in practice this is
             # extremely unlikely and would take a large crowd and good aim to achieve.
-            D:BeamDamage=7.0
+            D:BeamDamage=30.0
 
             # The range in meters of the Impulse Cannon's beam attack.
             D:BeamRange=32.0
@@ -201,7 +201,7 @@ gameplay {
             # Note that the damage cooldown of an entity hit by the first 2 rounds of the burst is reset
             # to allow the other rounds to do damage.
             # Since there are three shots fired by the burst, the effective damage is three times this value.
-            D:BurstDamage=8.0
+            D:BurstDamage=40.0
 
             # The range in meters of the Impulse Cannon's burst attack.
             D:BurstRange=24.0
@@ -217,7 +217,7 @@ gameplay {
 
             # The amount of damage that the Impulse Cannon's railgun attack does.
             # Note that the beam can pierce through multiple entities, but not blocks.
-            D:RailgunDamage=30.0
+            D:RailgunDamage=150.0
 
             # The range in meters of the Impulse Cannon's railgun attack.
             D:RailgunRange=64.0


### PR DESCRIPTION
Seeing as the Railgun has been buffed, and Thaumcraft has a lack of useful tools, i believe buffing the Impetus Cannon, a much more lategame (in Thaumcraft anyway) and similar tool to the Railgun, would be a good idea.
Damage values set in this PR are very much not final and probably need fine-tuning, i just booped the numbers up a bunch.