### PR TITLE
Reduce Champion level of Dreadful Peat Mummy

### DIFF
--- a/Client/overrides/config/champions.cfg
+++ b/Client/overrides/config/champions.cfg
@@ -43,7 +43,7 @@ general {
         minecraft:ender_dragon;2
         dungeonsmod:king;3
         dungeonsmod:sun;4
-        thebetweenlands:dreadful_mummy;4
+        thebetweenlands:dreadful_mummy;1
         minecraft:wither;2
         primitivemobs:trollager;2
         twilightforest:naga;1


### PR DESCRIPTION
The Betweenlands is already tough enough as-is, adding a gigantic difficulty spike like this to it really messes with its balance, turning it down to level 1 or 2 is more reasonable.