### PR TITLE
Update dungeontactics.cfg

### DIFF
--- a/Client/overrides/config/dungeontactics.cfg
+++ b/Client/overrides/config/dungeontactics.cfg
@@ -532,7 +532,7 @@
     I:"Mithril Ore"=2
 
     # Set higher for more Dungeon Tactics Mushrooms. [range: 0 ~ 100, default: 32]
-    I:"Mushroom Generation"=32
+    I:"Mushroom Generation"=0
 
     # Number of times to attempt to generate Gold per chunk. Set to 0 to disable Gold from being generated in the Nether. [range: 0 ~ 100, default: 6]
     I:"Nether Gold"=0


### PR DESCRIPTION
The mushrooms are only turned into ore and sometimes drop themselves during worldgen, causing lag by existing as a dropped item.