### PR TITLE
Remove Sound Muffler from ExtraUtilities

### DIFF
--- a/Client/overrides/config/extrautils2.cfg
+++ b/Client/overrides/config/extrautils2.cfg
@@ -92,7 +92,7 @@ enabled {
     B:Screen=true
     B:SimpleDecorative=true
     B:Snowglobe=true
-    B:SoundMuffler=true
+    B:SoundMuffler=false
     B:Spotlight=true
     B:SunCrystal=true
     B:SuperMobSpawner=true


### PR DESCRIPTION
it has a bug with ae2 and other mods where it will just crash
we already have others mufflers, like the one from random things