### PR TITLE
Fixes Astral Sorcery

### DIFF
--- a/Client/overrides/config/unidict/IntegrationModule.cfg
+++ b/Client/overrides/config/unidict/IntegrationModule.cfg
@@ -6,7 +6,7 @@ integrations {
     B:AdvancedRocketry=true
     B:AdvancedSolarPanels=true
     B:AppliedEnergistics2=true
-    B:AstralSorcery=true
+    B:AstralSorcery=false
     B:BaseMetals=true
     B:BloodMagic=true
     B:Chickens=true


### PR DESCRIPTION
remove integration because it was making the grindstone not work with rock crystals and celestial crystals