### PR TITLE
REORGANIZE SCRIPTS!

### DIFF
--- a/Client/overrides/scripts/AE2.zs
+++ b/Client/overrides/scripts/AE2.zs
@@ -5,22 +5,6 @@ print("--- loading AE2.zs ---");
 
 #Remove Items
 Grinder.removeRecipe(<nuclearcraft:flour>);
-recipes.remove(<wings:evil_wings>);
-recipes.remove(<wings:dragon_wings>);
-recipes.remove(<wings:angel_wings>);
-recipes.remove(<wings:slime_wings>);
-recipes.remove(<wings:blue_butterfly_wings>);
-recipes.remove(<wings:fire_wings>);
-recipes.remove(<wings:bat_wings>);
-recipes.remove(<wings:fairy_wings>);
-recipes.addShaped(<wings:bat_wings>, [[<wings:bat_blood>, <wings:amethyst>, <wings:bat_blood>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
-recipes.addShaped(<wings:fire_wings>, [[<mod_lavacow:mootenheart>, <wings:amethyst>, <mod_lavacow:mootenheart>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
-recipes.addShaped(<wings:blue_butterfly_wings>, [[<minecraft:lapis_block>, <wings:amethyst>, <minecraft:lapis_block>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
-recipes.addShaped(<wings:fairy_wings>, [[<fairylights:light:9>, <wings:amethyst>, <fairylights:light:9>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
-recipes.addShaped(<wings:slime_wings>, [[<minecraft:slime>, <wings:amethyst>, <minecraft:slime>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
-recipes.addShaped(<wings:dragon_wings>, [[<rats:dragon_wing>, <wings:amethyst>, <rats:dragon_wing>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
-recipes.addShaped(<wings:angel_wings>, [[<ore:dustFairy>, <wings:amethyst>, <ore:dustFairy>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
-recipes.addShaped(<wings:evil_wings>, [[<ore:blockCoal>, <wings:amethyst>, <ore:blockCoal>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
 Grinder.addRecipe(<nuclearcraft:flour>, <ore:cropWheat>, 5);
 
 

--- a/Client/overrides/scripts/AdvRocketry.zs
+++ b/Client/overrides/scripts/AdvRocketry.zs
@@ -1,0 +1,22 @@
+#MC Eternal Scripts
+
+print("--- loading AdvRocketry.zs ---");
+
+#Remove Recipes
+recipes.remove(<advancedrocketry:stationbuilder>);
+recipes.remove(<advancedrocketry:chemicalreactor>);
+recipes.remove(<advancedrocketry:fuelingstation>);
+recipes.remove(<advancedrocketry:rocketbuilder>);
+recipes.remove(<erebus:gaean_keystone>);
+recipes.remove(<erebus:portal_activator>);
+recipes.remove(<atum:scarab>);
+recipes.remove(<theaurorian:aurorianportalframebricks>);
+recipes.remove(<from_the_depths:block_altar_of_summoning>);
+
+#Add Recipes
+recipes.addShaped(<advancedrocketry:stationbuilder>, [[<advancedrocketry:ic:2>, <rats:arcane_technology>, <advancedrocketry:ic:2>], [<ore:dustDilithium>, <stevescarts:upgrade:5>, <libvulpes:productdust>], [<advancedrocketry:ic:2>, <ore:componentEVCapacitor>, <advancedrocketry:ic:2>]]);
+recipes.addShaped(<advancedrocketry:chemicalreactor>, [[<mekanism:polyethene>, <ore:itemPrecientCrystal>, <mekanism:polyethene>], [<ore:componentEVCapacitor>, <ore:blockCoil>, <ore:componentEVCapacitor>], [<ore:componentControlCircuit>, <twilightforest:tower_device:12>, <ore:componentControlCircuit>]]);
+recipes.addShaped(<advancedrocketry:fuelingstation>, [[<ore:crystalIron>, <ore:componentEVCapacitor>, <ore:crystalIron>], [<ore:gearTitanium>, <ore:componentControlCircuit>, <ore:gearTitanium>], [<ore:crystalIron>, <ore:componentEVCapacitor>, <ore:crystalIron>]]);
+recipes.addShaped(<advancedrocketry:rocketbuilder>, [[<ore:ingotBrickNetherGlazed>, <ore:gearTitanium>, <ore:ingotBrickNetherGlazed>], [<ore:itemPrecientCrystal>, <ore:componentComputerChip>, <ore:itemPrecientCrystal>], [<ore:ingotBrickNetherGlazed>, <powersuits:powerarmorcomponent:12>, <ore:ingotBrickNetherGlazed>]]);
+
+print("--- AdvRocketry.zs initialized ---");	

--- a/Client/overrides/scripts/Akt.zs
+++ b/Client/overrides/scripts/Akt.zs
@@ -2,7 +2,7 @@ import crafttweaker.item.IIngredient;
 import crafttweaker.item.IItemStack;
 import crafttweaker.oredict.IOreDict;
 import crafttweaker.oredict.IOreDictEntry;
-
+	recipes.remove(<akashictome:tome>);
 	var finishedTome = <akashictome:tome>.withTag(
 
 	{

--- a/Client/overrides/scripts/Cyclic.zs
+++ b/Client/overrides/scripts/Cyclic.zs
@@ -4,6 +4,5 @@ print("--- loading Cyclic.zs ---");
 
 #Remove Items
 recipes.remove(<cyclicmagic:glowing_chorus>);
-recipes.remove(<akashictome:tome>);
 
 print("--- Cyclic.zs initialized ---");	

--- a/Client/overrides/scripts/Decaster.zs
+++ b/Client/overrides/scripts/Decaster.zs
@@ -1,0 +1,57 @@
+import crafttweaker.item.IItemStack;
+import crafttweaker.liquid.ILiquidStack;
+#MC Eternal Scripts
+
+print("--- loading Decaster.zs ---");
+
+#list of Part types
+var allparttypes = [
+"tconstruct:pick_head",
+"tconstruct:shovel_head",
+"tconstruct:axe_head",
+"tconstruct:broad_axe_head",
+"tconstruct:sword_blade",
+"tconstruct:large_sword_blade",
+"tconstruct:hammer_head",
+"tconstruct:excavator_head",
+"tconstruct:kama_head",
+"tconstruct:scythe_head",
+"tconstruct:pan_head",
+"tconstruct:sign_head",
+"tconstruct:tool_rod",
+"tconstruct:tough_tool_rod",
+"tconstruct:binding",
+"tconstruct:tough_binding",
+"tconstruct:wide_guard",
+"tconstruct:hand_guard",
+"tconstruct:cross_guard",
+"tconstruct:large_plate",
+"tconstruct:knife_blade",
+"tconstruct:bow_limb",
+"tconstruct:arrow_head",
+"conarm:armor_trim",
+"conarm:armor_plate",
+"conarm:helmet_core",
+"conarm:chest_core",
+"conarm:leggings_core",
+"conarm:boots_core"] as string[];
+
+#Materials to remove parts from
+#Warning tooltip will also be added to these parts
+val materialnames = ["vibranium"] as string[];
+val liquidmaterialnames = [<liquid:vibranium_fluid>] as ILiquidStack[];
+
+#Warning Tooltip addition
+for stuff in materialnames {
+	for parts in allparttypes {
+		itemUtils.getItem(parts).withTag({Material: stuff as string}).addTooltip(format.red("WARNING: This Tool part has a Crash associated with it, it has been disabled to avoid that issue."));
+		mods.tconstruct.Casting.removeTableRecipe(itemUtils.getItem(parts).withTag({Material: stuff as string}));
+	}
+}
+
+#Bolt Cores
+for fluids in liquidmaterialnames {
+	mods.tconstruct.Casting.removeTableRecipe(<tconstruct:bolt_core>, fluids);
+}
+
+print("--- Decaster.zs initialized ---");

--- a/Client/overrides/scripts/DungeonTactics.zs
+++ b/Client/overrides/scripts/DungeonTactics.zs
@@ -1,12 +1,14 @@
+import crafttweaker.item.IItemTransformer;
 #MC Eternal Scripts
 
 print("--- loading DungeonTactics.zs ---");
 
 #Remove Items
 recipes.remove(<dungeontactics:iron_ring>);
+recipes.removeShapeless(<thermalfoundation:material:768>, [<dungeontactics:mortar&pestle>], true);
 
 #Add Recipes
 recipes.addShaped(<dungeontactics:iron_ring>, [[<ore:nuggetIron>, <ore:nuggetIron>, <ore:nuggetIron>], [<minecraft:iron_nugget>, null, <ore:nuggetIron>], [<ore:nuggetIron>, <ore:nuggetIron>, <ore:nuggetIron>]]);
-
+recipes.addShapeless(<thermalfoundation:material:768>, [<dungeontactics:mortar&pestle:*>.transformDamage(), <minecraft:coal:0>]);
 
 print("--- DungeonTactics.zs initialized ---");	

--- a/Client/overrides/scripts/EnderIO.zs
+++ b/Client/overrides/scripts/EnderIO.zs
@@ -1,0 +1,9 @@
+#MC Eternal Scripts
+
+print("--- loading EnderIO.zs ---");
+
+#Soul Binder
+#Fix for Flight Control Unit recipe being broken
+mods.enderio.SoulBinder.addRecipe(<simplyjetpacks:metaitemmods:6>, <simplyjetpacks:metaitemmods:5>, ["bat"], 8, 75000);
+
+print("--- EnderIO.zs initialized ---");

--- a/Client/overrides/scripts/ExtraUtils.zs
+++ b/Client/overrides/scripts/ExtraUtils.zs
@@ -17,6 +17,8 @@ recipes.remove(<extrautils2:angelring:5>);
 recipes.remove(<extrautils2:angelring>);
 
 recipes.remove(<extrautils2:teleporter:1>);
+recipes.remove(<extrautils2:lawsword>);
+recipes.remove(<extrautils2:quarry>);
 
 #Add Recipes
 #Glass wings
@@ -31,5 +33,9 @@ recipes.addShaped(<extrautils2:angelring:4>, [[<extrautils2:angelblock>, <extrau
 recipes.addShaped(<extrautils2:angelring:5>, [[<midnight:nagrilite_ingot>, <extrautils2:angelring>]]);
 #Crafting recipe normal angle ring
 recipes.addShaped(<extrautils2:angelring>, [[<mekanism:crystal:1>, <mekanism:crystal:2>, <mekanism:crystal:1>], [<twilightforest:trophy:5>, <tconstruct:materials:50>, <thebetweenlands:ring_of_dispersion>], [<mekanism:crystal:1>, <simplyjetpacks:metaitemmods:29>, <mekanism:crystal:1>]]);
+#Kikoku
+recipes.addShaped(<extrautils2:lawsword>, [[<extrautils2:opinium:8>], [<extrautils2:opinium:8>], [<theaurorian:livingdiviningrod>]]);
+#Quantum Quarry
+recipes.addShaped(<extrautils2:quarry>, [[<ore:blockCerulean>, <theaurorian:moongem>, <ore:blockCerulean>], [<theaurorian:moongem>, <ore:magic_snow_globe>, <theaurorian:moongem>], [<ore:blockCerulean>, <theaurorian:moongem>, <ore:blockCerulean>]]);
 
 print("--- ExtrUtils.zs initialized ---");

--- a/Client/overrides/scripts/FairyDust.zs
+++ b/Client/overrides/scripts/FairyDust.zs
@@ -1,0 +1,37 @@
+#MC Eternal Scripts
+
+print("--- loading FairyDust.zs ---");
+
+#Add Recipes
+recipes.addShaped(<ebwizardry:grand_crystal>, [[<ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>], [<wings:fairy_dust>, <ebwizardry:magic_crystal>, <wings:fairy_dust>], [<ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>]]);
+recipes.addShaped(<ebwizardry:charm_haggler>, [[<minecraft:gold_ingot>, <minecraft:gold_block>, <ore:ingotGold>], [<wings:fairy_dust>, <minecraft:gold_ingot>, <wings:fairy_dust>], [null, <minecraft:gold_block>, null]]);
+recipes.addShaped(<ebwizardry:charm_spell_discovery>, [[<minecraft:gold_ingot>, <minecraft:gold_block>, <ore:ingotGold>], [<wings:fairy_dust>, <minecraft:gold_ingot>, <wings:fairy_dust>], [null, <wings:fairy_dust>, null]]);
+recipes.addShaped(<ebwizardry:amulet_banishing>, [[<minecraft:gold_ingot>, null, <ore:ingotGold>], [null, <minecraft:gold_ingot>, null], [null, <wings:fairy_dust>, null]]);
+recipes.addShaped(<ebwizardry:magic_crystal>, [[<wings:fairy_dust>]]);
+recipes.addShaped(<ebwizardry:amulet_warding>, [[null, <ebwizardry:magic_crystal>, null], [<ore:dustFairy>, <minecraft:iron_block>, <ore:dustFairy>], [null, <ebwizardry:magic_crystal>, null]]);
+recipes.addShaped(<ebwizardry:arcane_tome:3>, [[<iceandfire:sea_serpent_scale_block_purple>, <ebwizardry:magic_crystal>, <iceandfire:sea_serpent_scale_block_purple>], [<wings:fairy_dust>, <ancientspellcraft:charm_evergrowing_crystal>, <wings:fairy_dust>], [<iceandfire:sea_serpent_scale_block_purple>, <ebwizardry:magic_crystal>, <iceandfire:sea_serpent_scale_block_purple>]]);
+recipes.addShaped(<ebwizardry:ring_battlemage>, [[null, <ore:dustFairy>, null], [<ore:dustFairy>, <dungeontactics:golden_ring>, <ore:dustFairy>], [null, <ore:dustFairy>, null]]);
+recipes.addShaped(<rats:arcane_technology>, [[<futuremc:netherite_ingot>, <ebwizardry:magic_crystal>, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:emerald_block>, <wings:fairy_dust>], [<futuremc:netherite_ingot>, <ebwizardry:magic_crystal>, <futuremc:netherite_ingot>]]);
+recipes.addShaped(<biomesoplenty:sapling_0:3>, [[<wings:fairy_dust>, <ebwizardry:magic_crystal>, <wings:fairy_dust>], [<wings:fairy_dust>, <ore:treeSapling>, <wings:fairy_dust>], [<wings:fairy_dust>, <ebwizardry:magic_crystal>, <wings:fairy_dust>]]);
+recipes.addShaped(<twilightforest:minotaur_axe_gold>, [[<minecraft:gold_ingot>, <minecraft:gold_ingot>], [<minecraft:gold_ingot>, <wings:fairy_dust>], [null, <wings:fairy_dust>]]);
+recipes.addShaped(<ancientwarfarestructure:golden_idol>, [[null, <ore:blockGold>, null], [<minecraft:gold_block>, <ore:dustFairy>, <ore:blockGold>], [<ore:blockGold>, <ancientwarfarestructure:coin_stack_gold>, <minecraft:gold_block>]]);
+recipes.addShaped(<minecraft:iron_ingot>, [[null, <ore:dustFairy>, null], [<ore:dustFairy>, <minecraft:gold_ingot>, <ore:dustFairy>], [null, <ore:dustFairy>, null]]);
+recipes.addShaped(<minecraft:gold_ingot>, [[null, <ore:dustFairy>, null], [<ore:dustFairy>, <ore:ingotIron>, <ore:dustFairy>], [null, <ore:dustFairy>, null]]);
+recipes.addShaped(<ancientspellcraft:charm_bucket_coal>, [[<wings:fairy_dust>, null, <wings:fairy_dust>], [<wings:fairy_dust>, <minecraft:coal>, <wings:fairy_dust>], [null, <wings:fairy_dust>, null]]);
+recipes.addShaped(<twilightforest:magic_beans>, [[<wings:fairy_dust>, <wings:fairy_dust>, <wings:fairy_dust>], [<wings:fairy_dust>, <mowziesmobs:foliaath_seed>, <wings:fairy_dust>], [<wings:fairy_dust>, <wings:fairy_dust>, <wings:fairy_dust>]]);
+recipes.addShaped(<thebetweenlands:ancient_boots>, [[<futuremc:netherite_ingot>, null, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:chainmail_boots>, <wings:fairy_dust>]]);
+recipes.addShaped(<thebetweenlands:ancient_chestplate>, [[<futuremc:netherite_ingot>, null, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:chainmail_chestplate>, <wings:fairy_dust>], [<wings:fairy_dust>, <wings:fairy_dust>, <wings:fairy_dust>]]);
+recipes.addShaped(<thebetweenlands:ancient_leggings>, [[<futuremc:netherite_ingot>, null, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:chainmail_leggings>, <wings:fairy_dust>], [<wings:fairy_dust>, null, <wings:fairy_dust>]]);
+recipes.addShaped(<thebetweenlands:ancient_helmet>, [[<ancientwarfare:component:5>, null, <ancientwarfare:component:5>], [<wings:fairy_dust>, <minecraft:chainmail_helmet>, <wings:fairy_dust>], [<wings:fairy_dust>, null, <wings:fairy_dust>]]);
+recipes.addShaped(<cyclicmagic:purple_chestplate>, [[<ore:dustFairy>, <minecraft:sea_lantern>, <wings:fairy_dust>], [<wings:fairy_dust>, <minecraft:iron_chestplate>, <wings:fairy_dust>], [<wings:fairy_dust>, <minecraft:sea_lantern>, <wings:fairy_dust>]]);
+recipes.addShaped(<minecraft:dirt:2>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <minecraft:dirt>, <wings:fairy_dust>], [null, <ore:dustFairy>, null]]);
+recipes.addShaped(<minecraft:sand>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <minecraft:gravel>, <wings:fairy_dust>], [null, <ore:dustFairy>, null]]);
+recipes.addShaped(<minecraft:gravel>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <minecraft:sand>, <wings:fairy_dust>], [null, <ore:dustFairy>, null]]);
+recipes.addShaped(<theaurorian:moonstonesword>, [[null, <futuremc:netherite_scrap>, <futuremc:netherite_ingot>], [null, <minecraft:diamond_sword>, <futuremc:netherite_scrap>], [<wings:fairy_dust>, null, null]]);
+recipes.addShaped(<twilightforest:ice_sword>, [[null, <wings:fairy_dust>, <wings:fairy_dust>], [null, <minecraft:golden_sword>, <wings:fairy_dust>], [<wings:fairy_dust>, null, null]]);
+recipes.addShaped(<twilightforest:steeleaf_sword>, [[null, <ore:dustFairy>, <wings:fairy_dust>], [null, <minecraft:iron_sword>, <wings:fairy_dust>], [<wings:fairy_dust>, null, null]]);
+recipes.addShaped(<harvestcraft:fairybreaditem>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <harvestcraft:cinnamonbreaditem>, <wings:fairy_dust>], [null, <wings:fairy_dust>, null]]);
+recipes.addShaped(<ancientspellcraft:ring_mana_transfer>, [[null, <ebwizardry:magic_crystal>, null], [<ore:dustFairy>, <dungeontactics:golden_ring>, <ore:dustFairy>], [null, <ebwizardry:magic_crystal>, null]]);
+recipes.addShaped(<ancientspellcraft:ring_prismarine>, [[null, <ore:gemPrismarine>, null], [<ore:dustFairy>, <dungeontactics:golden_ring>, <ore:dustFairy>], [null, <ore:gemPrismarine>, null]]);
+
+print("--- FairyDust.zs initialized ---");	

--- a/Client/overrides/scripts/ICBM.zs
+++ b/Client/overrides/scripts/ICBM.zs
@@ -9,9 +9,6 @@ recipes.remove(<icbmclassic:launcherbase>);
 recipes.remove(<icbmclassic:explosives:1>);
 recipes.remove(<icbmclassic:explosives:22>);
 recipes.remove(<icbmclassic:explosives>);
-recipes.remove(<thermalexpansion:frame>);
-recipes.remove(<extrautils2:lawsword>);
-recipes.remove(<mekanism:machineblock:8>);
 recipes.remove(<icbmclassic:explosives:15>);
 recipes.remove(<icbmclassic:explosives:23>);
 recipes.remove(<icbmclassic:battery>);
@@ -21,9 +18,6 @@ recipes.removeShaped(<icbmclassic:launcherbase:1>, [[<mekanism:ingot>, <techrebo
 #Add recipes
 recipes.addShaped(<icbmclassic:explosives:22>, [[<techreborn:ingot:25>, <techreborn:plates:38>, <techreborn:ingot:25>], [<extrautils2:compressedcobblestone:7>, <icbmclassic:explosives:15>, <extrautils2:compressedcobblestone:7>], [<techreborn:ingot:25>, <minecraft:bedrock>, <techreborn:ingot:25>]]);
 recipes.addShaped(<icbmclassic:explosives:23>, [[<extrautils2:compressedcobblestone:7>, <extrautils2:compressedcobblestone:7>, <extrautils2:compressedcobblestone:7>], [<extrautils2:compressedcobblestone:7>, <icbmclassic:explosives:15>, <extrautils2:compressedcobblestone:7>], [<extrautils2:compressedcobblestone:7>, <extrautils2:compressedcobblestone:7>, <extrautils2:compressedcobblestone:7>]]);
-recipes.addShaped(<extrautils2:lawsword>, [[<extrautils2:opinium:8>], [<extrautils2:opinium:8>], [<theaurorian:livingdiviningrod>]]);
-recipes.addShaped(<mekanism:machineblock:8>, [[<futuremc:netherite_ingot>, <ancientwarfarevehicle:major_alloy>, <futuremc:netherite_ingot>], [<minecraft:redstone>, <mekanism:basicblock>, <minecraft:redstone>], [<futuremc:netherite_ingot>, <ancientwarfarevehicle:major_alloy>, <futuremc:netherite_ingot>]]);
-recipes.addShaped(<thermalexpansion:frame>, [[<ore:blockSheetmetalLead>, <immersiveintelligence:material:4>, <ore:blockSheetmetalLead>], [<immersiveintelligence:material_spring>, <immersiveengineering:metal_decoration0:2>, <immersiveintelligence:material_spring>], [<ore:blockSheetmetalLead>, <immersiveintelligence:metal_decoration:2>, <ore:blockSheetmetalLead>]]);
 recipes.addShaped(<icbmclassic:launcherbase:1>, [[<mekanism:ingot>, <techreborn:cable:6>, <mekanism:ingot>], [<mekanism:ingot>, <icbmclassic:launcherbase>, <mekanism:ingot>], [<mekanism:ingot>, <techreborn:lapotroncrystal>, <mekanism:ingot>]]);
 recipes.addShaped(<icbmclassic:launcherframe>, [[<techreborn:plates:2>, <techreborn:cable:6>, <techreborn:plates:2>], [<techreborn:plates:2>, null, <techreborn:plates:2>], [<techreborn:plates:2>, <techreborn:lapotroncrystal>, <techreborn:plates:2>]]);
 recipes.addShaped(<icbmclassic:launcherbase>, [[<techreborn:plates:2>, null, <techreborn:plates:2>], [<techreborn:plates:2>, <techreborn:cable:6>, <techreborn:plates:2>], [<techreborn:plates:2>, <techreborn:lapotroncrystal>, <techreborn:plates:2>]]);

--- a/Client/overrides/scripts/InventoryPets.zs
+++ b/Client/overrides/scripts/InventoryPets.zs
@@ -4,53 +4,9 @@ print("--- loading InventoryPets.zs ---");
 
 #Remove Items
 recipes.remove(<inventorypets:nugget_coal>);
-recipes.remove(<mekanismgenerators:generator:3>);
-recipes.remove(<extrautils2:quarry>);
-recipes.remove(<rftools:builder>);
-recipes.remove(<mekanismgenerators:reactor>);
-recipes.remove(<rftoolsdim:dimension_builder>);
-recipes.remove(<mekanism:machineblock:4>);
-recipes.remove(<wings:monarch_butterfly_wings>);
 recipes.removeShapeless(<inventorypets:nugget_coal> * 8, [<minecraft:coal>]);
 
 #Add Recipes
 recipes.addShapeless(<inventorypets:nugget_coal> * 8, [<immersiveengineering:tool>, <ore:itemCoal>]);
-recipes.addShaped(<rats:arcane_technology>, [[<futuremc:netherite_ingot>, <ebwizardry:magic_crystal>, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:emerald_block>, <wings:fairy_dust>], [<futuremc:netherite_ingot>, <ebwizardry:magic_crystal>, <futuremc:netherite_ingot>]]);
-recipes.addShaped(<ebwizardry:arcane_tome:3>, [[<iceandfire:sea_serpent_scale_block_purple>, <ebwizardry:magic_crystal>, <iceandfire:sea_serpent_scale_block_purple>], [<wings:fairy_dust>, <ancientspellcraft:charm_evergrowing_crystal>, <wings:fairy_dust>], [<iceandfire:sea_serpent_scale_block_purple>, <ebwizardry:magic_crystal>, <iceandfire:sea_serpent_scale_block_purple>]]);
-recipes.addShaped(<biomesoplenty:sapling_0:3>, [[<wings:fairy_dust>, <ebwizardry:magic_crystal>, <wings:fairy_dust>], [<wings:fairy_dust>, <ore:treeSapling>, <wings:fairy_dust>], [<wings:fairy_dust>, <ebwizardry:magic_crystal>, <wings:fairy_dust>]]);
-recipes.addShaped(<ebwizardry:grand_crystal>, [[<ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>], [<wings:fairy_dust>, <ebwizardry:magic_crystal>, <wings:fairy_dust>], [<ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>, <ebwizardry:magic_crystal>]]);
-recipes.addShaped(<ebwizardry:charm_haggler>, [[<minecraft:gold_ingot>, <minecraft:gold_block>, <ore:ingotGold>], [<wings:fairy_dust>, <minecraft:gold_ingot>, <wings:fairy_dust>], [null, <minecraft:gold_block>, null]]);
-recipes.addShaped(<ebwizardry:charm_spell_discovery>, [[<minecraft:gold_ingot>, <minecraft:gold_block>, <ore:ingotGold>], [<wings:fairy_dust>, <minecraft:gold_ingot>, <wings:fairy_dust>], [null, <wings:fairy_dust>, null]]);
-recipes.addShaped(<ebwizardry:amulet_banishing>, [[<minecraft:gold_ingot>, null, <ore:ingotGold>], [null, <minecraft:gold_ingot>, null], [null, <wings:fairy_dust>, null]]);
-recipes.addShaped(<twilightforest:minotaur_axe_gold>, [[<minecraft:gold_ingot>, <minecraft:gold_ingot>], [<minecraft:gold_ingot>, <wings:fairy_dust>], [null, <wings:fairy_dust>]]);
-recipes.addShaped(<ancientwarfarestructure:golden_idol>, [[null, <ore:blockGold>, null], [<minecraft:gold_block>, <ore:dustFairy>, <ore:blockGold>], [<ore:blockGold>, <ancientwarfarestructure:coin_stack_gold>, <minecraft:gold_block>]]);
-recipes.addShaped(<minecraft:iron_ingot>, [[null, <ore:dustFairy>, null], [<ore:dustFairy>, <minecraft:gold_ingot>, <ore:dustFairy>], [null, <ore:dustFairy>, null]]);
-recipes.addShaped(<minecraft:gold_ingot>, [[null, <ore:dustFairy>, null], [<ore:dustFairy>, <ore:ingotIron>, <ore:dustFairy>], [null, <ore:dustFairy>, null]]);
-recipes.addShaped(<ancientspellcraft:charm_bucket_coal>, [[<wings:fairy_dust>, null, <wings:fairy_dust>], [<wings:fairy_dust>, <minecraft:coal>, <wings:fairy_dust>], [null, <wings:fairy_dust>, null]]);
-recipes.addShaped(<twilightforest:magic_beans>, [[<wings:fairy_dust>, <wings:fairy_dust>, <wings:fairy_dust>], [<wings:fairy_dust>, <mowziesmobs:foliaath_seed>, <wings:fairy_dust>], [<wings:fairy_dust>, <wings:fairy_dust>, <wings:fairy_dust>]]);
-recipes.addShaped(<thebetweenlands:ancient_boots>, [[<futuremc:netherite_ingot>, null, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:chainmail_boots>, <wings:fairy_dust>]]);
-recipes.addShaped(<thebetweenlands:ancient_chestplate>, [[<futuremc:netherite_ingot>, null, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:chainmail_chestplate>, <wings:fairy_dust>], [<wings:fairy_dust>, <wings:fairy_dust>, <wings:fairy_dust>]]);
-recipes.addShaped(<thebetweenlands:ancient_leggings>, [[<futuremc:netherite_ingot>, null, <futuremc:netherite_ingot>], [<wings:fairy_dust>, <minecraft:chainmail_leggings>, <wings:fairy_dust>], [<wings:fairy_dust>, null, <wings:fairy_dust>]]);
-recipes.addShaped(<thebetweenlands:ancient_helmet>, [[<ancientwarfare:component:5>, null, <ancientwarfare:component:5>], [<wings:fairy_dust>, <minecraft:chainmail_helmet>, <wings:fairy_dust>], [<wings:fairy_dust>, null, <wings:fairy_dust>]]);
-recipes.addShaped(<cyclicmagic:purple_chestplate>, [[<ore:dustFairy>, <minecraft:sea_lantern>, <wings:fairy_dust>], [<wings:fairy_dust>, <minecraft:iron_chestplate>, <wings:fairy_dust>], [<wings:fairy_dust>, <minecraft:sea_lantern>, <wings:fairy_dust>]]);
-recipes.addShaped(<minecraft:dirt:2>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <minecraft:dirt>, <wings:fairy_dust>], [null, <ore:dustFairy>, null]]);
-recipes.addShaped(<minecraft:sand>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <minecraft:gravel>, <wings:fairy_dust>], [null, <ore:dustFairy>, null]]);
-recipes.addShaped(<minecraft:gravel>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <minecraft:sand>, <wings:fairy_dust>], [null, <ore:dustFairy>, null]]);
-recipes.addShaped(<theaurorian:moonstonesword>, [[null, <futuremc:netherite_scrap>, <futuremc:netherite_ingot>], [null, <minecraft:diamond_sword>, <futuremc:netherite_scrap>], [<wings:fairy_dust>, null, null]]);
-recipes.addShaped(<twilightforest:ice_sword>, [[null, <wings:fairy_dust>, <wings:fairy_dust>], [null, <minecraft:golden_sword>, <wings:fairy_dust>], [<wings:fairy_dust>, null, null]]);
-recipes.addShaped(<twilightforest:steeleaf_sword>, [[null, <ore:dustFairy>, <wings:fairy_dust>], [null, <minecraft:iron_sword>, <wings:fairy_dust>], [<wings:fairy_dust>, null, null]]);
-recipes.addShaped(<harvestcraft:fairybreaditem>, [[null, <wings:fairy_dust>, null], [<wings:fairy_dust>, <harvestcraft:cinnamonbreaditem>, <wings:fairy_dust>], [null, <wings:fairy_dust>, null]]);
-recipes.addShaped(<ebwizardry:magic_crystal>, [[<wings:fairy_dust>]]);
-recipes.addShaped(<ebwizardry:amulet_warding>, [[null, <ebwizardry:magic_crystal>, null], [<ore:dustFairy>, <minecraft:iron_block>, <ore:dustFairy>], [null, <ebwizardry:magic_crystal>, null]]);
-recipes.addShaped(<ancientspellcraft:ring_mana_transfer>, [[null, <ebwizardry:magic_crystal>, null], [<ore:dustFairy>, <dungeontactics:golden_ring>, <ore:dustFairy>], [null, <ebwizardry:magic_crystal>, null]]);
-recipes.addShaped(<ancientspellcraft:ring_prismarine>, [[null, <ore:gemPrismarine>, null], [<ore:dustFairy>, <dungeontactics:golden_ring>, <ore:dustFairy>], [null, <ore:gemPrismarine>, null]]);
-recipes.addShaped(<ebwizardry:ring_battlemage>, [[null, <ore:dustFairy>, null], [<ore:dustFairy>, <dungeontactics:golden_ring>, <ore:dustFairy>], [null, <ore:dustFairy>, null]]);
-recipes.addShaped(<mekanismgenerators:generator:3>, [[<mekanism:clump:2>, <mekanism:atomicalloy>, <mekanism:clump:2>], [<futuremc:netherite_block>, <mekanism:electrolyticcore>, <futuremc:netherite_block>], [<mekanism:clump:2>, <mekanism:atomicalloy>, <mekanism:clump:2>]]);
-recipes.addShaped(<extrautils2:quarry>, [[<ore:blockCerulean>, <theaurorian:moongem>, <ore:blockCerulean>], [<theaurorian:moongem>, <ore:magic_snow_globe>, <theaurorian:moongem>], [<ore:blockCerulean>, <theaurorian:moongem>, <ore:blockCerulean>]]);
-recipes.addShaped(<mekanismgenerators:reactor>, [[<mekanism:controlcircuit:3>, <thaumicaugmentation:starfield_glass:2>, <mekanism:controlcircuit:3>], [<ore:blockNetherite>, <advancedrocketry:chemicalreactor>.giveBack(<advancedrocketry:chemicalreactor>), <futuremc:netherite_block>], [<ore:blockNetherite>, <ore:blockAurorianSteel>, <ore:blockNetherite>]]);
-recipes.addShaped(<rftools:builder>, [[<theaurorian:auroriancoalblock>, <mekanism:controlcircuit:3>, <theaurorian:auroriancoalblock>], [<mekanism:machineblock:15>, <twilightforest:tower_device:6>, <mekanism:machineblock:15>], [<theaurorian:auroriancoalblock>, <mekanism:teleportationcore>, <theaurorian:auroriancoalblock>]]);
-recipes.addShaped(<rftoolsdim:dimension_builder>, [[<futuremc:netherite_ingot>, <futuremc:netherite_ingot>, <futuremc:netherite_ingot>], [<mekanism:machineblock:15>, <ore:blockAurorianSteel>, <mekanism:machineblock:15>], [<mekanism:teleportationcore>, <mekanism:robit>, <mekanism:teleportationcore>]]);
-recipes.addShaped(<mekanism:machineblock:4>, [[<ore:alloyUltimate>, <mekanism:controlcircuit:3>, <ore:alloyUltimate>], [<mekanism:machineblock:15>, <mekanism:robit>, <mekanism:machineblock:15>], [<mekanism:teleportationcore>, <futuremc:netherite_block>, <mekanism:teleportationcore>]]);
-recipes.addShaped(<wings:monarch_butterfly_wings>, [[<mysticalagriculture:mystical_flower_essence>, <ore:gemAmethyst>, <mysticalagriculture:mystical_flower_essence>], [<futuremc:netherite_ingot>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
 
-print("--- InventoryPets.zs initialized ---");	
+print("--- InventoryPets.zs initialized ---");

--- a/Client/overrides/scripts/Mekanism.zs
+++ b/Client/overrides/scripts/Mekanism.zs
@@ -2,7 +2,17 @@
 
 print("--- loading Mekanism.zs ---");
 
-#Remove Items
+#Remove Item(s)
 recipes.remove(<mekanism:salt>);
+recipes.remove(<mekanism:machineblock:8>);
+recipes.remove(<mekanism:machineblock:4>);
+recipes.remove(<mekanismgenerators:reactor>);
+recipes.remove(<mekanismgenerators:generator:3>);
+
+#Add Recipe(s)
+recipes.addShaped(<mekanism:machineblock:8>, [[<futuremc:netherite_ingot>, <ancientwarfarevehicle:major_alloy>, <futuremc:netherite_ingot>], [<minecraft:redstone>, <mekanism:basicblock>, <minecraft:redstone>], [<futuremc:netherite_ingot>, <ancientwarfarevehicle:major_alloy>, <futuremc:netherite_ingot>]]);
+recipes.addShaped(<mekanism:machineblock:4>, [[<ore:alloyUltimate>, <mekanism:controlcircuit:3>, <ore:alloyUltimate>], [<mekanism:machineblock:15>, <mekanism:robit>, <mekanism:machineblock:15>], [<mekanism:teleportationcore>, <futuremc:netherite_block>, <mekanism:teleportationcore>]]);
+recipes.addShaped(<mekanismgenerators:reactor>, [[<mekanism:controlcircuit:3>, <thaumicaugmentation:starfield_glass:2>, <mekanism:controlcircuit:3>], [<ore:blockNetherite>, <advancedrocketry:chemicalreactor>.giveBack(<advancedrocketry:chemicalreactor>), <futuremc:netherite_block>], [<ore:blockNetherite>, <ore:blockAurorianSteel>, <ore:blockNetherite>]]);
+recipes.addShaped(<mekanismgenerators:generator:3>, [[<mekanism:clump:2>, <mekanism:atomicalloy>, <mekanism:clump:2>], [<futuremc:netherite_block>, <mekanism:electrolyticcore>, <futuremc:netherite_block>], [<mekanism:clump:2>, <mekanism:atomicalloy>, <mekanism:clump:2>]]);
 
 print("--- Mekanism.zs initialized ---");	

--- a/Client/overrides/scripts/RFTools.zs
+++ b/Client/overrides/scripts/RFTools.zs
@@ -1,0 +1,14 @@
+#MC Eternal Scripts
+
+print("--- loading RFTools.zs ---");
+
+
+#Remove Items
+recipes.remove(<rftools:builder>);
+recipes.remove(<rftoolsdim:dimension_builder>);
+
+#Add Recipes
+recipes.addShaped(<rftools:builder>, [[<theaurorian:auroriancoalblock>, <mekanism:controlcircuit:3>, <theaurorian:auroriancoalblock>], [<mekanism:machineblock:15>, <twilightforest:tower_device:6>, <mekanism:machineblock:15>], [<theaurorian:auroriancoalblock>, <mekanism:teleportationcore>, <theaurorian:auroriancoalblock>]]);
+recipes.addShaped(<rftoolsdim:dimension_builder>, [[<futuremc:netherite_ingot>, <futuremc:netherite_ingot>, <futuremc:netherite_ingot>], [<mekanism:machineblock:15>, <ore:blockAurorianSteel>, <mekanism:machineblock:15>], [<mekanism:teleportationcore>, <mekanism:robit>, <mekanism:teleportationcore>]]);
+
+print("--- RFTools.zs initialized ---");

--- a/Client/overrides/scripts/Techreborn.zs
+++ b/Client/overrides/scripts/Techreborn.zs
@@ -4,22 +4,9 @@ print("--- loading Techreborn.zs ---");
 
 #Remove Items
 recipes.remove(<techreborn:grinder>);
-recipes.remove(<erebus:gaean_keystone>);
-recipes.remove(<erebus:portal_activator>);
-recipes.remove(<atum:scarab>);
-recipes.remove(<theaurorian:aurorianportalframebricks>);
-recipes.remove(<from_the_depths:block_altar_of_summoning>);
-recipes.remove(<advancedrocketry:stationbuilder>);
-recipes.remove(<advancedrocketry:chemicalreactor>);
-recipes.remove(<advancedrocketry:fuelingstation>);
-recipes.remove(<advancedrocketry:rocketbuilder>);
 
 #Add Recipes
-recipes.addShaped(<advancedrocketry:stationbuilder>, [[<advancedrocketry:ic:2>, <rats:arcane_technology>, <advancedrocketry:ic:2>], [<ore:dustDilithium>, <stevescarts:upgrade:5>, <libvulpes:productdust>], [<advancedrocketry:ic:2>, <ore:componentEVCapacitor>, <advancedrocketry:ic:2>]]);
 recipes.addShaped(<techreborn:grinder>, [[<techreborn:cable:4>, <techreborn:iron_furnace>, <techreborn:cable:4>], [<minecraft:flint>, <techreborn:part:40>, <minecraft:flint>]]);
 recipes.addShaped(<techreborn:chunk_loader>, [[<techreborn:part:5>, <ore:enderpearl>, <techreborn:part:5>], [<mekanism:ingot>, <techreborn:part:41>, <ore:ingotRefinedObsidian>], [<ore:lapotronCrystal>, <techreborn:plates:32>, <ore:lapotronCrystal>]]);
-recipes.addShaped(<advancedrocketry:chemicalreactor>, [[<mekanism:polyethene>, <ore:itemPrecientCrystal>, <mekanism:polyethene>], [<ore:componentEVCapacitor>, <ore:blockCoil>, <ore:componentEVCapacitor>], [<ore:componentControlCircuit>, <twilightforest:tower_device:12>, <ore:componentControlCircuit>]]);
-recipes.addShaped(<advancedrocketry:fuelingstation>, [[<ore:crystalIron>, <ore:componentEVCapacitor>, <ore:crystalIron>], [<ore:gearTitanium>, <ore:componentControlCircuit>, <ore:gearTitanium>], [<ore:crystalIron>, <ore:componentEVCapacitor>, <ore:crystalIron>]]);
-recipes.addShaped(<advancedrocketry:rocketbuilder>, [[<ore:ingotBrickNetherGlazed>, <ore:gearTitanium>, <ore:ingotBrickNetherGlazed>], [<ore:itemPrecientCrystal>, <ore:componentComputerChip>, <ore:itemPrecientCrystal>], [<ore:ingotBrickNetherGlazed>, <powersuits:powerarmorcomponent:12>, <ore:ingotBrickNetherGlazed>]]);
 
 print("--- Techreborn.zs initialized ---");	

--- a/Client/overrides/scripts/Thermal.zs
+++ b/Client/overrides/scripts/Thermal.zs
@@ -2,7 +2,11 @@
 
 print("--- loading Thermal.zs ---");
 
+#Remove Recipe
+recipes.remove(<thermalexpansion:frame>);
+
 #Add Recipe
 recipes.addShaped(<thermalfoundation:material:160>, [[<ore:dustObsidian>, <ore:dustCoal>, <ore:dustObsidian>], [<ore:dustCoal>, <ore:ingotBrass>, <ore:dustCoal>], [<ore:dustObsidian>, <ore:dustCoal>, <thermalfoundation:material:770>]]);
+recipes.addShaped(<thermalexpansion:frame>, [[<ore:blockSheetmetalLead>, <immersiveintelligence:material:4>, <ore:blockSheetmetalLead>], [<immersiveintelligence:material_spring>, <immersiveengineering:metal_decoration0:2>, <immersiveintelligence:material_spring>], [<ore:blockSheetmetalLead>, <immersiveintelligence:metal_decoration:2>, <ore:blockSheetmetalLead>]]);
 
 print("--- Thermal.zs initialized ---");	

--- a/Client/overrides/scripts/Wings.zs
+++ b/Client/overrides/scripts/Wings.zs
@@ -1,0 +1,26 @@
+#MC Eternal Scripts
+
+print("--- loading Wings.zs ---");
+
+#Remove Recipes
+recipes.remove(<wings:evil_wings>);
+recipes.remove(<wings:dragon_wings>);
+recipes.remove(<wings:angel_wings>);
+recipes.remove(<wings:slime_wings>);
+recipes.remove(<wings:blue_butterfly_wings>);
+recipes.remove(<wings:fire_wings>);
+recipes.remove(<wings:bat_wings>);
+recipes.remove(<wings:fairy_wings>);
+recipes.remove(<wings:monarch_butterfly_wings>);
+
+#Add Recipes
+recipes.addShaped(<wings:bat_wings>, [[<wings:bat_blood>, <wings:amethyst>, <wings:bat_blood>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+recipes.addShaped(<wings:fire_wings>, [[<mod_lavacow:mootenheart>, <wings:amethyst>, <mod_lavacow:mootenheart>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+recipes.addShaped(<wings:blue_butterfly_wings>, [[<minecraft:lapis_block>, <wings:amethyst>, <minecraft:lapis_block>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+recipes.addShaped(<wings:fairy_wings>, [[<fairylights:light:9>, <wings:amethyst>, <fairylights:light:9>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+recipes.addShaped(<wings:slime_wings>, [[<minecraft:slime>, <wings:amethyst>, <minecraft:slime>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+recipes.addShaped(<wings:dragon_wings>, [[<rats:dragon_wing>, <wings:amethyst>, <rats:dragon_wing>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+recipes.addShaped(<wings:angel_wings>, [[<ore:dustFairy>, <wings:amethyst>, <ore:dustFairy>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+recipes.addShaped(<wings:evil_wings>, [[<ore:blockCoal>, <wings:amethyst>, <ore:blockCoal>], [<ore:ingotNetherite>, <ore:dustFairy>, <ore:ingotNetherite>], [<ore:ingotNetherite>, null, <ore:ingotNetherite>]]);
+
+print("--- Wings.zs initialized ---");


### PR DESCRIPTION
Reorganizes all the Scripts.
Adds 6 new files, 4 of which contain lines migrated from others, the other 2 are fixes requested by Bread.

Decaster.zs is an easily augmentable script to remove Part casting from specified materials, currently in use to remove Vibranium to avoid the Heroic trait crash.
The Soul Binder line in EnderIO.zs is to add back the Flight Control Unit recipe, as it is broken in the current used version of Simply Jetpacks 2.
Changes to DungeonTactics.zs fix the issue in #61. Ore mushroom recipes were not fixed because they were disabled as of #64.
Recipes with Fairy Dust were in too big of numbers to warrant each mod getting its own Script.
Space-gated Dim-related items are in AR script because it makes the most sense, and avoids script clutter.

Pls don't do this again Adam :(