### PR TITLE
Disable Shielding effect from Champions

### DIFF
--- a/Client/overrides/config/champions/affixes.json
+++ b/Client/overrides/config/champions/affixes.json
@@ -85,7 +85,7 @@
   },
   {
     "identifier": "shielding",
-    "enabled": true,
+    "enabled": false,
     "entityBlacklist": [],
     "alwaysOnEntity": [],
     "tier": 1


### PR DESCRIPTION
Causes more annoyance than challenge overall, and with Champions already being quite bulky, we don't need them to take actual hours to kill sometimes.