### PR TITLE
Add Corail Tombstones to Moving Wall Break blacklist

### DIFF
--- a/Client/overrides/config/thebetweenlands/config.cfg
+++ b/Client/overrides/config/thebetweenlands/config.cfg
@@ -137,6 +137,10 @@ general {
     # A list of blocks that should not be broken by the moving walls. Syntax is "modid:blockname:meta", meta can be * for wildcard, if no meta is provided 0 is used
     S:moving_wall_blacklist <
         tombmanygraves:grave_block
+        tombstone:grave_cross
+        tombstone:grave_normal
+        tombstone:grave_simple
+        tombstone:tombstone
      >
 
     # Whether the online fan art gallery picture frame should be enabled and be allowed to download fan art that has been manually picked by the developers to be shown in the gallery picture frame


### PR DESCRIPTION
With Corail Tombstone being back in the pack, adding these to the blacklist of breakable blocks for Moving Walls from The Betweenlands is a good idea.