### PR TITLE
Fix alloying of Mirion

### DIFF
--- a/Client/overrides/scripts/TinkersConstruct.zs
+++ b/Client/overrides/scripts/TinkersConstruct.zs
@@ -10,4 +10,7 @@ mods.tconstruct.Alloy.removeRecipe(<liquid:steel>);
 mods.tconstruct.Alloy.removeRecipe(<liquid:electrumflux>);
 mods.tconstruct.Melting.removeRecipe(<liquid:electrumflux>);
 
+#Add alternate Mirion alloying
+mods.tconstruct.Alloy.addRecipe(<liquid:mirion>*72, [<liquid:manasteel>*18, <liquid:elvenelementium>*18, <liquid:terrasteel>*18, <liquid:cobalt>*18, <liquid:glass>*125]);
+
 print("--- TinkersConstruct.zs initialized ---");	


### PR DESCRIPTION
Default Mirion recipe calls for "elementium" liquid, but the game prefers to melt Elementium into "elvenelementium" liquid, this PR will add a secondary recipe that allows use of "elvenelementium" to create molten Mirion.