### PR TITLE
Remove lively/dampening/adaptable from some bosses

### DIFF
--- a/Client/overrides/config/champions/affixes.json
+++ b/Client/overrides/config/champions/affixes.json
@@ -58,7 +58,7 @@
   {
     "identifier": "lively",
     "enabled": true,
-    "entityBlacklist": [],
+    "entityBlacklist": ["twilightforest:ur_ghast", "twilightforest:hydra", "twilightforest:lich"],
     "alwaysOnEntity": [],
     "tier": 1
   },

--- a/Client/overrides/config/champions/affixes.json
+++ b/Client/overrides/config/champions/affixes.json
@@ -51,7 +51,7 @@
   {
     "identifier": "dampening",
     "enabled": true,
-    "entityBlacklist": [],
+    "entityBlacklist": ["twilightforest:ur_ghast", "twilightforest:hydra", "twilightforest:lich"],
     "alwaysOnEntity": [],
     "tier": 1
   },
@@ -65,7 +65,7 @@
   {
     "identifier": "adaptable",
     "enabled": true,
-    "entityBlacklist": [],
+    "entityBlacklist": ["twilightforest:ur_ghast", "twilightforest:hydra", "twilightforest:lich"],
     "alwaysOnEntity": [],
     "tier": 1
   },


### PR DESCRIPTION
i'm removing it from some bosses from twilight because of the boss progression fight
ur_ghast
hydra
lich

Ur ghast, hydra and lich have mechanics on which they need to be damaged by a indirect source and it needs to be the same, if you're doing the progression correcly