### PR TITLE
Remove main Beneath Ores from Botania Orechid

### DIFF
--- a/Client/overrides/scripts/GoToTheBeneath.zs
+++ b/Client/overrides/scripts/GoToTheBeneath.zs
@@ -1,0 +1,11 @@
+#MC Eternal Scripts
+
+print("--- loading GoToTheBeneath.zs ---");
+
+#Remove Beneath ores from Orechid
+mods.botania.Orechid.removeOre("oreOsmium");
+mods.botania.Orechid.removeOre("oreBoron");
+mods.botania.Orechid.removeOre("oreLithium");
+mods.botania.Orechid.removeOre("oreMagnesium");
+
+print("--- GoToTheBeneath.zs initialized ---");


### PR DESCRIPTION
Removes Osmium, Boron, Lithium, and Magnesium from the Orechid's possible ores, does not remove Uranium or Thorium, but those can be easily added on request.
Uranium and Thorium were not removed to allow for a renewable source of them (alongside the many other methods), since not all people particularly like the idea of a nonrenewable power source in modded MC.