### PR TITLE
Move Builder recipe alteration to Quarry Card

### DIFF
--- a/Client/overrides/scripts/RFTools.zs
+++ b/Client/overrides/scripts/RFTools.zs
@@ -4,11 +4,11 @@ print("--- loading RFTools.zs ---");
 
 
 #Remove Items
-recipes.remove(<rftools:builder>);
+recipes.remove(<rftools:shape_card:2>);
 recipes.remove(<rftoolsdim:dimension_builder>);
 
 #Add Recipes
-recipes.addShaped(<rftools:builder>, [[<theaurorian:auroriancoalblock>, <mekanism:controlcircuit:3>, <theaurorian:auroriancoalblock>], [<mekanism:machineblock:15>, <twilightforest:tower_device:6>, <mekanism:machineblock:15>], [<theaurorian:auroriancoalblock>, <mekanism:teleportationcore>, <theaurorian:auroriancoalblock>]]);
+recipes.addShaped(<rftools:shape_card:2>, [[<theaurorian:auroriancoalblock>, <mekanism:controlcircuit:3>, <theaurorian:auroriancoalblock>], [<mekanism:machineblock:15>, <twilightforest:tower_device:6>, <mekanism:machineblock:15>], [<theaurorian:auroriancoalblock>, <mekanism:teleportationcore>, <theaurorian:auroriancoalblock>]]);
 recipes.addShaped(<rftoolsdim:dimension_builder>, [[<futuremc:netherite_ingot>, <futuremc:netherite_ingot>, <futuremc:netherite_ingot>], [<mekanism:machineblock:15>, <ore:blockAurorianSteel>, <mekanism:machineblock:15>], [<mekanism:teleportationcore>, <mekanism:robit>, <mekanism:teleportationcore>]]);
 
 print("--- RFTools.zs initialized ---");


### PR DESCRIPTION
Enables earlier use of the Builder to, well, Build, since the Quarrying function seemed to be most of the worry.