### PR TITLE
Consider removing normal preprocessor from AdvRocketry.zs

### DIFF
--- a/Client/overrides/scripts/AdvRocketry.zs
+++ b/Client/overrides/scripts/AdvRocketry.zs
@@ -1,4 +1,4 @@
-#packmode normal
+#MC Eternal Scripts
 
 print("--- loading AdvRocketry.zs ---");
 


### PR DESCRIPTION
Keeping it is generally a bad idea due to how planets are set up, everything accessible is far stronger than usual, which will no doubt lead to complaints, and also for slight balancing reasons, leaving Aurorian materials just partially open like that with the likely buff and existing powerful gear is not the best of ideas.