### PR TITLE
Add Sphere of Cognizance quest

### DIFF
--- a/Client/overrides/config/ftbquests/normal/chapters/bec752d7/20813292.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/bec752d7/20813292.snbt
@@ -15,5 +15,15 @@
 		items: [{
 			item: "ancientspellcraft:sphere_cognizance"
 		}]
+	}],
+	rewards: [{
+		uid: "315c99bd",
+		type: "ftbmoney:money",
+		ftb_money: 100L
+	},
+	{
+		uid: "dd4c1a90",
+		type: "loot",
+		table: 1
 	}]
 }

--- a/Client/overrides/config/ftbquests/normal/chapters/bec752d7/20813292.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/bec752d7/20813292.snbt
@@ -1,0 +1,19 @@
+{
+	x: 7.0d,
+	y: -2.0d,
+	description: "Identifying Spells made easier!",
+	text: [
+		"The Sphere of Cognizance is a device that can consume Magic Crystals to provide information about the various properties of a Spell, and sometimes instantly Identify it!",
+		"Just give it a Spell Book, some Magic Crystals, and press the button in its GUI to get hints."
+	],
+	dependencies: [
+		"66a69ac3"
+	],
+	tasks: [{
+		uid: "a797f28e",
+		type: "item",
+		items: [{
+			item: "ancientspellcraft:sphere_cognizance"
+		}]
+	}]
+}


### PR DESCRIPTION
The Sphere of Cognizance is a useful device from Ancient Spellcraft that can help out a lot with identifying spells, as such, i believe it is worthy of a Quest.
Tab is Magic and Spellcasting, Reward is 100 Coins and Common loot.