### PR TITLE
Make Wing Durability stats equal

### DIFF
--- a/Client/overrides/config/wings/items.cfg
+++ b/Client/overrides/config/wings/items.cfg
@@ -7,7 +7,7 @@ angel {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=960
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -30,7 +30,7 @@ bat {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=1920
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -53,7 +53,7 @@ blue_butterfly {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=960
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -76,7 +76,7 @@ dragon {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=2880
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -99,7 +99,7 @@ evil {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=1920
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -122,7 +122,7 @@ fairy {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=960
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -145,7 +145,7 @@ fire {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=1920
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -168,7 +168,7 @@ monarch_butterfly {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=960
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0
@@ -191,7 +191,7 @@ slime {
 
     # Min: 0
     # Max: 32767
-    I:itemDurability=960
+    I:itemDurability=2000
 
     # Min: 0.0
     # Max: 10.0


### PR DESCRIPTION
All wings have the same base recipe with minor alterations based on what wing it is, they probably should be equal so that there's no definitive best, and it's purely a cosmetic choice.