### PR TITLE
Blackmarket and Common lootbox cleanup

### DIFF
--- a/Client/overrides/config/ftbquests/normal/reward_tables/8e152c32.snbt
+++ b/Client/overrides/config/ftbquests/normal/reward_tables/8e152c32.snbt
@@ -1360,47 +1360,6 @@
 	},
 	{
 		item: {
-			id: "minecraft:spawn_egg",
-			tag: {
-				EntityTag: {
-					id: "icbmclassic:skeleton.xmas.boss"
-				}
-			}
-		},
-		weight: 3
-	},
-	{
-		item: {
-			id: "minecraft:spawn_egg",
-			tag: {
-				EntityTag: {
-					id: "icbmclassic:skeleton.xmas.snowman"
-				}
-			}
-		}
-	},
-	{
-		item: {
-			id: "minecraft:spawn_egg",
-			tag: {
-				EntityTag: {
-					id: "icbmclassic:zombie.xmas.boss"
-				}
-			}
-		}
-	},
-	{
-		item: {
-			id: "minecraft:spawn_egg",
-			tag: {
-				EntityTag: {
-					id: "icbmclassic:zombie.xmas.creeper"
-				}
-			}
-		}
-	},
-	{
-		item: {
 			ForgeCaps: {
 				"astralsorcery:cap_item_amulet_holder": {}
 			},
@@ -2239,15 +2198,6 @@
 				"astralsorcery:cap_item_amulet_holder": {}
 			},
 			id: "iceandfire:amphithere_macuahuitl"
-		}
-	},
-	{
-		item: {
-			ForgeCaps: {
-				"astralsorcery:cap_item_amulet_holder": {}
-			},
-			id: "ebwizardry:armour_upgrade",
-			Count: 1b
 		}
 	},
 	{

--- a/Client/overrides/config/ftbquests/normal/reward_tables/dad26af0.snbt
+++ b/Client/overrides/config/ftbquests/normal/reward_tables/dad26af0.snbt
@@ -289,10 +289,6 @@
 		weight: 19
 	},
 	{
-		item: "extrautils2:soundmuffler",
-		weight: 19
-	},
-	{
 		item: {
 			ForgeCaps: {
 				"astralsorcery:cap_item_amulet_holder": {}
@@ -1045,11 +1041,6 @@
 	},
 	{
 		item: "cyclicmagic:apple_emerald",
-		weight: 22
-	},
-	{
-		item: "cyclicmagic:corrupted_chorus",
-		count: 3,
 		weight: 22
 	},
 	{
@@ -1954,16 +1945,6 @@
 	},
 	{
 		item: {
-			id: "thermalexpansion:morb",
-			tag: {
-				Generic: 1b,
-				id: "icbmclassic:zombie.xmas.elf"
-			}
-		},
-		weight: 26
-	},
-	{
-		item: {
 			id: "biomestaff:biome_staff",
 			tag: {
 				biome: -102b
@@ -2088,17 +2069,6 @@
 	},
 	{
 		item: "rats:rat_upgrade_buccaneer",
-		weight: 26
-	},
-	{
-		item: {
-			id: "minecraft:spawn_egg",
-			tag: {
-				EntityTag: {
-					id: "icbmclassic:zombie.xmas.creeper"
-				}
-			}
-		},
 		weight: 26
 	},
 	{
@@ -2531,11 +2501,6 @@
 	},
 	{
 		item: "bewitchment:flying_ointment",
-		weight: 18
-	},
-	{
-		item: "davincisvessels:balloon",
-		count: 16,
 		weight: 18
 	},
 	{


### PR DESCRIPTION
Removes ICBM mob Morbs and Spawn Eggs, old EBWizardry armor upgrade, Davinci's Vessels Balloons, and Cyclic Corrupted Chorus.