### PR TITLE
Max output of TechReborn's fusion 

### DIFF
--- a/Client/overrides/config/teamreborn/techreborn/machines.cfg
+++ b/Client/overrides/config/teamreborn/techreborn/machines.cfg
@@ -140,7 +140,7 @@ fusion_reactor {
     I:FusionReactorMaxInput=8192
 
     # Fusion Reactor Max Output (Value in EU) [Default=1000000]
-    I:FusionReactorMaxOutput=1000000
+    I:FusionReactorMaxOutput=100000000
 }
 
 


### PR DESCRIPTION
So TechReborn can make 62 million rf/t but the output was limited to only 4 million, i increased to 400million
![image](https://user-images.githubusercontent.com/5963821/123712538-e23fa980-d848-11eb-8d91-b2c405da0634.png)
