### PR TITLE
Make Legendary Infinity Drill quest only accept Legendary drills

### DIFF
--- a/Client/overrides/config/ftbquests/classic/chapters/3bc6db27/1f1dad8c.snbt
+++ b/Client/overrides/config/ftbquests/classic/chapters/3bc6db27/1f1dad8c.snbt
@@ -1,4 +1,5 @@
 {
+	title: "§6Infinity Drill [Legendary]",
 	x: -3.5d,
 	y: -7.0d,
 	dependencies: [
@@ -13,16 +14,10 @@
 			},
 			id: "industrialforegoing:infinity_drill",
 			tag: {
-				Energy: 3360000000L,
-				Fluid: {
-					FluidName: "biofuel",
-					Amount: 0
-				},
-				Special: 0b,
 				Selected: "LEGENDARY"
 			}
 		}],
-		ignore_nbt: 1b
+		ignore_nbt: 2b
 	}],
 	rewards: [{
 		uid: "60f11687",

--- a/Client/overrides/config/ftbquests/normal/chapters/3bc6db27/1f1dad8c.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/3bc6db27/1f1dad8c.snbt
@@ -1,4 +1,5 @@
 {
+	title: "§6Infinity Drill [Legendary]",
 	x: -3.5d,
 	y: -7.0d,
 	dependencies: [
@@ -13,16 +14,10 @@
 			},
 			id: "industrialforegoing:infinity_drill",
 			tag: {
-				Energy: 3360000000L,
-				Fluid: {
-					FluidName: "biofuel",
-					Amount: 0
-				},
-				Special: 0b,
 				Selected: "LEGENDARY"
 			}
 		}],
-		ignore_nbt: 1b
+		ignore_nbt: 2b
 	}],
 	rewards: [{
 		uid: "60f11687",
@@ -30,3 +25,4 @@
 		ftb_money: 50000L
 	}]
 }
+


### PR DESCRIPTION
Fix tested in Lite 1.3.8 dev, may not work for some reason, but very unlikely.