### PR TITLE
Complety Disable Multishot for real

### DIFF
--- a/Client/overrides/scripts/DisableMultishot.zs
+++ b/Client/overrides/scripts/DisableMultishot.zs
@@ -1,0 +1,19 @@
+import crafttweaker.events.IEventManager;
+import crafttweaker.enchantments.IEnchantment;
+import crafttweaker.enchantments.IEnchantmentDefinition;
+import crafttweaker.item.IItemStack;
+import crafttweaker.player.IPlayer;
+
+events.onEntityLivingUseItemStart(function(event as crafttweaker.event.EntityLivingUseItemEvent.Start){
+	if(event.isPlayer){
+		if(event.item.isEnchanted){
+			var multishoot = <enchantment:cofhcore:multishot>.id;
+			var listenchants as IEnchantment[] = event.item.enchantments as IEnchantment[];
+			for enchts in listenchants {
+				if(multishoot == enchts.definition.id){
+					event.player.dropItem(true);
+				}
+			}
+		}
+	}
+});


### PR DESCRIPTION
for real this time!

```
explaining what happens in this script

everytime a player start using a item, it checks
- if it's a player
	-if the item used is enchanted
		-if the item has the enchatment multishot
```

this will only trigger with items that can be used, aka it wont active with swords