### PR TITLE
Update methods

### DIFF
--- a/Client/overrides/scripts/DisableMultishot.zs
+++ b/Client/overrides/scripts/DisableMultishot.zs
@@ -11,16 +11,7 @@ events.onEntityLivingUseItemStart(function(event as crafttweaker.event.EntityLiv
 			var listenchants as IEnchantment[] = event.item.enchantments as IEnchantment[];
 			for enchts in listenchants {
 				if(multishoot == enchts.definition.id){
-					if(!isNull(event.player.mainHandHeldItem)){
-						if(event.player.mainHandHeldItem.matches(event.item)){
-							event.player.dropItem(true);
-						}
-					}
-					if(!isNull(event.player.offHandHeldItem)){
-						if(event.player.offHandHeldItem.matches(event.item)){
-							event.player.setItemToSlot(crafttweaker.entity.IEntityEquipmentSlot.offhand(), null);
-						}
-					}
+					event.cancel();
 					event.player.sendChat("Multishot is disabled, but the player " ~ event.player.name ~ " tried to use anyways.");
 				}
 			}

--- a/Client/overrides/scripts/DisableMultishot.zs
+++ b/Client/overrides/scripts/DisableMultishot.zs
@@ -11,7 +11,17 @@ events.onEntityLivingUseItemStart(function(event as crafttweaker.event.EntityLiv
 			var listenchants as IEnchantment[] = event.item.enchantments as IEnchantment[];
 			for enchts in listenchants {
 				if(multishoot == enchts.definition.id){
-					event.player.dropItem(true);
+					if(!isNull(event.player.mainHandHeldItem)){
+						if(event.player.mainHandHeldItem.matches(event.item)){
+							event.player.dropItem(true);
+						}
+					}
+					if(!isNull(event.player.offHandHeldItem)){
+						if(event.player.offHandHeldItem.matches(event.item)){
+							event.player.setItemToSlot(crafttweaker.entity.IEntityEquipmentSlot.offhand(), null);
+						}
+					}
+					event.player.sendChat("Multishot is disabled, but the player " ~ event.player.name ~ " tried to use anyways.");
 				}
 			}
 		}

--- a/Client/overrides/scripts/DisableMultishot.zs
+++ b/Client/overrides/scripts/DisableMultishot.zs
@@ -12,7 +12,9 @@ events.onEntityLivingUseItemStart(function(event as crafttweaker.event.EntityLiv
 			for enchts in listenchants {
 				if(multishoot == enchts.definition.id){
 					event.cancel();
-					event.player.sendChat("Multishot is disabled, but the player " ~ event.player.name ~ " tried to use anyways.");
+					if (!event.player.world.isRemote()) {
+						event.player.sendChat("Multishot is disabled, but the player " ~ event.player.name ~ " tried to use anyways.");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
so i changed the way it drops the item, it first check if the item is in the mainhand or offhand, depending on which one it will set the item to null and then drop
the offhand one will set the offhand to null, but it wont drop, that's because the item is still there, but you cannot use it, that's for some smart-asses that will try do that to bypass

in the old one if the bow was in the offhand it wouldnt drop it