### PR TITLE
Make naturally spawning F&A mobs more rare

### DIFF
--- a/Client/overrides/config/fossil.cfg
+++ b/Client/overrides/config/fossil.cfg
@@ -2,7 +2,7 @@
 
 all {
     # Chance of Alligator Gars spawning in a new chunks. Higher number = more rare [range: 1 ~ 100000000, default: 3]
-    I:"Alligator Gar Spawn Rarity"=3
+    I:"Alligator Gar Spawn Rarity"=9
 
     # True if vanilla animals should run away from dinosaurs [default: false]
     B:"Animals Fear Dinosaurs"=false
@@ -14,7 +14,7 @@ all {
     I:"Aztec Weapon Shop Rarity"=400
 
     # Chance of Coelacanth spawning in a new chunks. Higher number = more rare [range: 1 ~ 100000000, default: 4]
-    I:"Coelacanth Spawn Rarity"=4
+    I:"Coelacanth Spawn Rarity"=15
 
     # True if Custom Main Menu is enabled [default: true]
     B:"Custom Main Menu"=false
@@ -146,7 +146,7 @@ all {
     I:"Moai Rarity"=400
 
     # Chance of Nautilus spawning in a new chunks. Higher number = more rare [range: 1 ~ 100000000, default: 6]
-    I:"Nautilus Spawn Rarity"=6
+    I:"Nautilus Spawn Rarity"=25
 
     # Rarity of Permafrost ore. Higher number = more common [range: 1 ~ 100000000, default: 4]
     I:"Permafrost Ore Rarity"=4
@@ -176,7 +176,7 @@ all {
     B:"Starving Dinos"=true
 
     # Chance of Sturgeon spawning in a new chunks. Higher number = more rare [range: 1 ~ 100000000, default: 4]
-    I:"Sturgeon Spawn Rarity"=4
+    I:"Sturgeon Spawn Rarity"=15
 
     # Chance of Tar Slimes spawning in a tarpit per tick. Higher number = more rare [range: 1 ~ 100000000, default: 75]
     I:"Tar Slime Spawn Rarity"=75


### PR DESCRIPTION
Nautilus especially, they spawn very often in oceans.
Potentially fixes #115