### PR TITLE
Reduce Banshee damage to 30 from 70

### DIFF
--- a/Client/overrides/config/Fishs_Undead_Rising.cfg
+++ b/Client/overrides/config/Fishs_Undead_Rising.cfg
@@ -23,7 +23,7 @@ avaton {
 
 banshee {
     # Banshee strength [1-1000]
-    D:"banshee attack"=70.0
+    D:"banshee attack"=30.0
 
     # Maximum Banshee health [1-1000]
     D:"banshee health"=340.0


### PR DESCRIPTION
They deal Magic damage with the scream, which ignores most armor.
sure it's fine if they oneshot you in low tier gear, but oneshot in high-tier gear is just silly.