### PR TITLE
Add Disabled tooltips to Pam's Gardens

### DIFF
--- a/Client/overrides/scripts/Harvestcraft.zs
+++ b/Client/overrides/scripts/Harvestcraft.zs
@@ -2,8 +2,13 @@
 
 print("--- loading Harvestcraft.zs ---");
 
+var pamgarden = ["arid","frost","shaded","soggy","tropical","windy"] as string[];
+
 #Add Recipe
 recipes.addShaped(<harvestcraft:toastitem>, [[<ore:cropCinnamon>, <dungeontactics:toast>]]);
 recipes.removeShapeless(<harvestcraft:plainyogurtitem> * 4, [<harvestcraft:plainyogurtitem>, <minecraft:leather>]);
+for gardens in pamgarden {
+	itemUtils.getItem("harvestcraft:"~gardens~"garden").addTooltip(format.red("Disabled, purchase Harvestcraft seeds from the Farming for Blockheads Market"));
+}
 
 print("--- Harvestcraft.zs initialized ---");	


### PR DESCRIPTION
They're disabled, so the player should be notified they don't spawn.