### PR TITLE
Alter Railgun and Revolver recipes to reflect buff

### DIFF
--- a/Client/overrides/scripts/Immersive.zs
+++ b/Client/overrides/scripts/Immersive.zs
@@ -1,0 +1,13 @@
+#MC Eternal Scripts
+
+print("--- loading Immersive.zs ---");
+
+#Remove Recipes
+recipes.remove(<immersiveengineering:railgun>);
+recipes.remove(<immersiveengineering:revolver>);
+
+#Add Recipes
+recipes.addShaped(<immersiveengineering:railgun>, [[<techreborn:cable:8>,<techreborn:cable:8>,<techreborn:cable:8>], [<immersiveengineering:material:13>,<powersuits:powerarmorcomponent:8>,<powersuits:powerarmorcomponent:19>], [<immersiveengineering:material:13>,<immersiveengineering:material:14>,<immersiveengineering:material:14>]]);
+recipes.addShaped(<immersiveengineering:revolver>, [[<powersuits:powerarmorcomponent:13>,<techreborn:part:24>,<immersiveengineering:material:16>], [<immersiveengineering:material:14>,<immersiveengineering:material:15>,<immersiveintelligence:material:14>], [null,<techreborn:part:1>,<immersiveengineering:material:13>]]);
+
+print("--- Tooltip.zs initialized ---");


### PR DESCRIPTION
Far too cheap for their current power, as it stands.
The normal mode preprocessor is missing from this split PR, we should have a little chat about if we want it to be there or not, i would definitely say it shouldn't.