### PR TITLE
Blacklist Rats from Erebus and DimDoors dimensions

### DIFF
--- a/Client/overrides/config/rats.cfg
+++ b/Client/overrides/config/rats.cfg
@@ -19,6 +19,12 @@ all {
 
     # Blacklist for dimensions that rats and pipers cannot spawn in
     I:"Blacklisted Rat Spawn Dimensions" <
+        66
+        684
+        685
+        686
+        687
+        688
      >
 
     # True if wild, untamed rats can despawn. [default: true]


### PR DESCRIPTION
Would spawn far too often in them, and even blocked up hostile spawns in Erebus, making it quite a bit easier.