### PR TITLE
Fix Problematic TCon traits better

### DIFF
--- a/Client/overrides/config/tweakersconstruct.cfg
+++ b/Client/overrides/config/tweakersconstruct.cfg
@@ -145,11 +145,34 @@ miscelleaneous {
     # The syntax is: MaterialID:Parts:Trait1,Trait2,etc.
     # To keep all existing traits add ":false" at the end [default: [paper:all:tasty], [paper:head:cheap], [paper:handle:autosmelt], [paper:extra:holy,hellish], [paper:bow:coldblooded], [paper:bowstring:crude], [paper:projectile:dense], [paper:shaft:heavy], [paper:fletching:alien]]
     S:"Trait tweaks" <
-        starmetal:all:dark
-        obsidiorite:all:dark
-        iridium:all:heavy
-        vibrant_alloy:all:heavy
-        ice_dragonsteel:all:heavy
+	gaia:head:alien,payback
+	gaia:handle:alien,payback
+	gaia:extra:alien,payback
+	gaia:core:alien_armor,manarepair
+	gaia:plates:alien_armor,manarepair
+	gaia:trim:alien_armor,manarepair
+	obsidiorite:head:alien
+	obsidiorite:handle:alien
+	obsidiorite:extra:alien
+	obsidiorite:core:alien_armor
+	obsidiorite:plates:alien_armor
+	obsidiorite:trim:alien_armor
+	dragonsteel_ice:head:freezing
+	dragonsteel_ice:handle:heavy
+	dragonsteel_ice:extra:heavy
+	dragonsteel_ice:core:indomitable_armor
+	dragonsteel_ice:plates:prideful_armor
+	dragonsteel_ice:trim:steady_armor
+	vibranium:all:dense
+	vibranium:head:dense
+	vibranium:extra:resonance
+	vibranium:handle:resonance
+	soularium:all:flammable
+	soularium:extra:splinters
+	soularium:head:hellish
+	soularium:core:superhot_armor
+	soularium:plates:infernal_armor
+	soularium:trim:vengeful_armor
 	jade:head:jaded,crumbling,botanical2,morganlefay
 	jade:handle:jaded,naturebound,crude2,slaughtering
 	jade:extra:jaded,naturebound,crude2,analysing


### PR DESCRIPTION
Gives Dragonsteel and Soularium new sets of traits, makes Gaia and no longer usable for Double Alien, Starmetal, Vibrant, Endsteel, and Iridium have proper Alien traits for armor, and can't cause Double Alien, so those are removed.
Does reintroduce I'm a Superstar trait, which could easily be considered very OP.