### PR TITLE
Make RFTools Shield actually usable

### DIFF
--- a/Client/overrides/config/rftools/rftools.cfg
+++ b/Client/overrides/config/rftools/rftools.cfg
@@ -1608,16 +1608,16 @@ shield {
     S:shieldDamage=5.0
 
     # Maximum RF storage that the shield block can hold [range: 0 ~ 2147483647, default: 200000]
-    I:shieldMaxRF=200000
+    I:shieldMaxRF=5000000
 
     # Maximum size (in blocks) of a tier 1 shield [range: 0 ~ 1000000, default: 256]
     I:shieldMaxSize=256
 
     # RF per tick that the shield block can receive [range: 0 ~ 2147483647, default: 5000]
-    I:shieldRFPerTick=5000
+    I:shieldRFPerTick=5000000
 
     # Base amount of RF/tick for every 10 blocks in the shield (while active) [range: 0 ~ 2147483647, default: 8]
-    I:shieldRfBase=8000
+    I:shieldRfBase=400
 
     # RF/tick for every 10 blocks added in case of camo mode [range: 0 ~ 2147483647, default: 2]
     I:shieldRfCamo=2


### PR DESCRIPTION
Could not be used effectively previously due to ludicrous power requirement, this PR increases its Energy capacity and RF/t rate, aswell as reducing the Power usage to 1/20th (50x default) of what it was previously set to.