### PR TITLE
Allow Dimension Builder to accept entire capacity of RF/t

### DIFF
--- a/Client/overrides/config/rftools/dimensions.cfg
+++ b/Client/overrides/config/rftools/dimensions.cfg
@@ -272,7 +272,7 @@ machines {
     I:dimensionBuilderMaxRF=10000000
 
     # RF per tick that the dimension builder can receive
-    I:dimensionBuilderRFPerTick=50000
+    I:dimensionBuilderRFPerTick=10000000
 
     # Maximum RF storage that the dimension editor can hold
     I:dimensionEditorMaxRF=5000000


### PR DESCRIPTION
The Maintence Cost boost seems still usable if you have proper endgame powergen, so i didn't touch it, it might not be so usable though.