### PR TITLE
Replace Endertweaker script lines with EnderIO XML recipes and update EIO

### DIFF
--- a/Client/manifest.json
+++ b/Client/manifest.json
@@ -780,11 +780,6 @@
       "required": true
     },
     {
-      "projectID": 312195,
-      "fileID": 3131262,
-      "required": true
-    },
-    {
       "projectID": 263048,
       "fileID": 2643354,
       "required": true
@@ -1291,7 +1286,7 @@
     },
     {
       "projectID": 64578,
-      "fileID": 3124452,
+      "fileID": 3328811,
       "required": true
     },
     {

--- a/Client/manifest.json
+++ b/Client/manifest.json
@@ -501,7 +501,7 @@
     },
     {
       "projectID": 309756,
-      "fileID": 3060489,
+      "fileID": 3328809,
       "required": true
     },
     {

--- a/Client/overrides/config/enderio/recipes/user/SAG_taiga_dust.xml
+++ b/Client/overrides/config/enderio/recipes/user/SAG_taiga_dust.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<enderio:recipes xmlns:enderio="http://enderio.com/recipes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://enderio.com/recipes recipes.xsd ">
+
+<recipe name="Sagmill: taiga_crush_abyssum" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:abyssum_ore"/>
+      <output name="taiga:abyssum_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_basalt" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:basalt_block"/>
+      <output name="taiga:basalt_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_tiberium" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:tiberium_ore"/>
+      <output name="taiga:tiberium_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_aurorium" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:aurorium_ore"/>
+      <output name="taiga:aurorium_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_prometheum" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:prometheum_ore"/>
+      <output name="taiga:prometheum_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_duranite" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:duranite_ore"/>
+      <output name="taiga:duranite_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_valyrium" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:valyrium_ore"/>
+      <output name="taiga:valyrium_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_vibranium" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:vibranium_ore"/>
+      <output name="taiga:vibranium_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_karmesine" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:karmesine_ore"/>
+      <output name="taiga:karmesine_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_ovium" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:ovium_ore"/>
+      <output name="taiga:ovium_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_jauxum" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:jauxum_ore"/>
+      <output name="taiga:jauxum_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_palladium" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:palladium_ore"/>
+      <output name="taiga:palladium_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_uru" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:uru_ore"/>
+      <output name="taiga:uru_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_osram" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:osram_ore"/>
+      <output name="taiga:osram_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_eezo" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:eezo_ore"/>
+      <output name="taiga:eezo_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+<recipe name="Sagmill: taiga_crush_dilithium" required="true">
+	<sagmilling energy="3600" bonus="none">
+      <input name="taiga:dilithium_ore"/>
+      <output name="taiga:dilithium_dust" amount="2"/>
+	</sagmilling>
+</recipe>
+
+</enderio:recipes>

--- a/Client/overrides/config/enderio/recipes/user/mce_fixes.xml
+++ b/Client/overrides/config/enderio/recipes/user/mce_fixes.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<enderio:recipes xmlns:enderio="http://enderio.com/recipes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://enderio.com/recipes recipes.xsd ">
+
+<!-- Fix Flight Control Unit from Simply Jetpacks -->
+<recipe name="Flight Control Unit fix" required="false">
+	<soulbinding energy="75000" levels="8">
+		<input name="item:simplyjetpacks:metaitemmods:5"/>
+		<soul name="minecraft:bat"/>
+		<output name="item:simplyjetpacks:metaitemmods:6"/>
+	</soulbinding>
+</recipe>
+
+</enderio:recipes>

--- a/Client/overrides/scripts/EnderIO.zs
+++ b/Client/overrides/scripts/EnderIO.zs
@@ -1,9 +1,0 @@
-#MC Eternal Scripts
-
-print("--- loading EnderIO.zs ---");
-
-#Soul Binder
-#Fix for Flight Control Unit recipe being broken
-mods.enderio.SoulBinder.addRecipe(<simplyjetpacks:metaitemmods:6>, <simplyjetpacks:metaitemmods:5>, ["bat"], 75000, 8);
-
-print("--- EnderIO.zs initialized ---");

--- a/Client/overrides/scripts/TaigaDusts.zs
+++ b/Client/overrides/scripts/TaigaDusts.zs
@@ -1,26 +1,9 @@
-import mods.enderio.SagMill;
 import mods.immersiveengineering.Crusher;
 import mods.mekanism.enrichment;
 import mods.mekanism.crusher;
 #MC Eternal Scripts
 
 print("--- loading TaigaDusts.zs ---");
-
-#Adding TAIGA Dusts to Ender IO
-mods.enderio.SagMill.addRecipe([<taiga:tiberium_ore>], [100], <taiga:tiberium_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:aurorium_ore>], [100], <taiga:aurorium_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:jauxum_ore>], [100], <taiga:jauxum_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:ovium_ore>], [100], <taiga:ovium_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:karmesine_ore>], [100], <taiga:karmesine_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:vibranium_ore>], [100], <taiga:vibranium_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:valyrium_ore>], [100], <taiga:valyrium_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:duranite_ore>], [100], <taiga:duranite_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:prometheum_ore>], [100], <taiga:prometheum_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:eezo_ore>], [100], <taiga:eezo_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:abyssum_ore>], [100], <taiga:abyssum_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:osram_ore>], [100], <taiga:osram_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:uru_ore>], [100], <taiga:uru_dust> *2);
-mods.enderio.SagMill.addRecipe([<taiga:palladium_ore>], [100], <taiga:palladium_dust> *2);
 
 #Adding TAIGA Dusts to Immersive Engineering
 mods.immersiveengineering.Crusher.addRecipe(<taiga:tiberium_dust>*2, <taiga:tiberium_ore>, 3048);


### PR DESCRIPTION
Updating EnderIO fixes a bunch of bugs, including the rather infamous Experience Obelisk bug.

Custom Recipe XMLs have been tested, aswell as Script removals.