### PR TITLE
Reduce Builder RF/block placement cost

### DIFF
--- a/Client/overrides/config/rftools/rftools.cfg
+++ b/Client/overrides/config/rftools/rftools.cfg
@@ -68,7 +68,7 @@ builder {
     I:builderRfPerLiquid=5000
 
     # RF per block operation for the builder when used to build [range: 0 ~ 2147483647, default: 500]
-    I:builderRfPerOperation=50000
+    I:builderRfPerOperation=2000
 
     # RF per player move operation for the builder [range: 0 ~ 2147483647, default: 40000]
     I:builderRfPerPlayer=40000


### PR DESCRIPTION
50k per block placed is pretty silly, and the total power use exceeds the max RF/t input of the Builder.