### PR TITLE
Reenable TechReborn Bauxite but make it rarer

### DIFF
--- a/Client/overrides/config/teamreborn/techreborn/ores.json
+++ b/Client/overrides/config/teamreborn/techreborn/ores.json
@@ -49,10 +49,10 @@
       "blockNiceName": "Bauxite",
       "meta": 4,
       "veinSize": 6,
-      "veinsPerChunk": 10,
+      "veinsPerChunk": 3,
       "minYHeight": 10,
       "maxYHeight": 60,
-      "shouldSpawn": false
+      "shouldSpawn": true
     },
     {
       "blockName": "tile.techreborn.ore",


### PR DESCRIPTION
Currently, the quest "Sticks and stone may break my bones" in Introduction to Science is half-impossible due to this, and Rutile is also fairly rare regardless.

It also wouldn't be terribly hard to add ways to convert TR bauxite into Aluminum if desired.