### PR TITLE
Blacklist Dragons in End

### DIFF
--- a/Client/overrides/config/ice_and_fire.cfg
+++ b/Client/overrides/config/ice_and_fire.cfg
@@ -50,6 +50,7 @@ all {
         66
         1048
         2000
+        1
      >
 
     # Misc Structures(Cyclops caves, Gorgon temples, etc) cannot spawn in these dimensions' IDs


### PR DESCRIPTION
They normally don't spawn in the default End biome, but they can in Stygian End's biomes.