### PR TITLE
Add Tips mod + 8 Custom tips

### DIFF
--- a/Client/manifest.json
+++ b/Client/manifest.json
@@ -1637,7 +1637,12 @@
       "projectID": 400488,
       "fileID": 3024769,
       "required": true
-    }
+    },
+	{
+	  "projectID": 306549,
+	  "fileID": 2906537,
+	  "required": true
+	}
   ],
   "overrides": "overrides"
 }

--- a/Client/overrides/config/tips.cfg
+++ b/Client/overrides/config/tips.cfg
@@ -1,0 +1,32 @@
+# Configuration file
+
+general {
+    # Determines whether or not the default tips should be possible. This includes tips added directly by other mods through their language files. [default: true]
+    B:allowDefaultTips=false
+
+    # A list of custom tips added by the user or modpack. [default: ]
+    S:customTips <
+	Join our Discord for help and support! §9https://discord.gg/ZS6FRR3§r
+	Osmium and Nuclearcraft Ores are only found in The Beneath
+	In MC Eternal, the Atum, Erebus, and Aurorian Dimensions can only be accessed through Advanced Rocketry
+	Legends say the Erebus holds a certain mineral with great power...
+	Legends say the Aurorian holds powerful foes, and a certain powerful Alloy...
+	Magic is the key to incredible power!
+	Tech is the key to tons of resources!
+	In MC Eternal, Skystone Meteorites are only found in The Beneath
+     >
+
+    # The color of the actual tip text. [default: FFFFFF]
+    S:textColor=FFFFFF
+
+    # The color of the top/title text for the tip. [default: FFFF55]
+    S:titleColor=FFFF55
+
+    # The amount of offset the tip text should have from the left of the screen. [range: 0 ~ 2147483647, default: 5]
+    I:xOffset=5
+
+    # The amount of offset the tip text should have from the bottom of the screen. [range: 0 ~ 2147483647, default: 40]
+    I:yOffset=40
+}
+
+

--- a/Client/overrides/config/tips.cfg
+++ b/Client/overrides/config/tips.cfg
@@ -14,6 +14,7 @@ general {
 	Magic is the key to incredible power!
 	Tech is the key to tons of resources!
 	In MC Eternal, Skystone Meteorites are only found in The Beneath
+	Never touched a certain mod before? Join the Discord for help!
      >
 
     # The color of the actual tip text. [default: FFFFFF]


### PR DESCRIPTION
Can be used to tell the player about custom changes and stuff on the loading screen, as shown by the examples in the config originally made for MCE Lite.

Distinct Lack of Tips atm, need more.