### PR TITLE
Tooltip adjustments + 4 New ones

### DIFF
--- a/Client/overrides/scripts/Mekanism.zs
+++ b/Client/overrides/scripts/Mekanism.zs
@@ -15,4 +15,7 @@ recipes.addShaped(<mekanism:machineblock:4>, [[<ore:alloyUltimate>, <mekanism:co
 recipes.addShaped(<mekanismgenerators:reactor>, [[<mekanism:controlcircuit:3>, <thaumicaugmentation:starfield_glass:2>, <mekanism:controlcircuit:3>], [<ore:blockNetherite>, <advancedrocketry:chemicalreactor>.giveBack(<advancedrocketry:chemicalreactor>), <futuremc:netherite_block>], [<ore:blockNetherite>, <ore:blockAurorianSteel>, <ore:blockNetherite>]]);
 recipes.addShaped(<mekanismgenerators:generator:3>, [[<mekanism:clump:2>, <mekanism:atomicalloy>, <mekanism:clump:2>], [<futuremc:netherite_block>, <mekanism:electrolyticcore>, <futuremc:netherite_block>], [<mekanism:clump:2>, <mekanism:atomicalloy>, <mekanism:clump:2>]]);
 
+#Info
+<mekanismgenerators:reactor>.addTooltip(format.gold("Only requires one Chemical Reactor for recipe"));
+
 print("--- Mekanism.zs initialized ---");	

--- a/Client/overrides/scripts/Tooltip.zs
+++ b/Client/overrides/scripts/Tooltip.zs
@@ -21,17 +21,8 @@ print("--- loading Tooltip.zs ---");
 <ftbquests:lootcrate>.withTag({type: "common_lootbox"}).addTooltip(format.gold("Random loot reward for completing a quest"));
 <ftbquests:lootcrate>.withTag({type: "unclaimed_black_market_container"}).addTooltip(format.gold("An item sold at a previous auction that was never picked up by the winning bidder. Buyer beware."));
 <nuclearcraft:ore:3>.addTooltip(format.darkPurple("Only found in the Beneath"));
-<immersiveengineering:ore:5>.addTooltip(format.darkPurple("Only found in the Beneath"));
 <icbmclassic:emptower>.addTooltip(format.darkPurple("Only obtainable from the Shop"));
-<nuclearcraft:ore:5>.addTooltip(format.darkPurple("Only found in the Beneath"));
-<nuclearcraft:ore:6>.addTooltip(format.darkPurple("Only found in the Beneath"));
-<nuclearcraft:ore:7>.addTooltip(format.darkPurple("Only found in the Beneath"));
-<mekanism:oreblock>.addTooltip(format.darkPurple("Only found in the Beneath"));
-<mysticalagriculture:supremium_helmet>.addTooltip(format.red("Disabled Flight"));
-<mysticalagriculture:supremium_chestplate>.addTooltip(format.red("Disabled Flight"));
-<mysticalagriculture:supremium_leggings>.addTooltip(format.red("Disabled Flight"));
-<mysticalagriculture:supremium_boots>.addTooltip(format.red("Disabled Flight"));
-<cyclicmagic:inventory_food>.addTooltip(format.red("WARNING! Can deletes items when the game crash or close unexpectedly"));
+<cyclicmagic:inventory_food>.addTooltip(format.red("WARNING! Can delete items inside when the game crashes or closes unexpectedly"));
 <cookingforblockheads:sink>.addTooltip(format.red("Does not produce Infinite Water"));
 <immersiveengineering:railgun>.addTooltip(format.lightPurple("Damage amplified to 40x"));
 <immersiveengineering:revolver>.addTooltip(format.lightPurple("Bullet Damage values amplified to ~15x"));
@@ -43,20 +34,27 @@ print("--- loading Tooltip.zs ---");
 <appliedenergistics2:sky_compass>.addTooltip(format.red("Only Spawns in The Beneath and on The Moon"));
 <lootgames:ms_activator>.addTooltip(format.red("WARNING: DO NOT PLACE IN YOUR BASE"));
 
-var text = "If used as an AE2 Autocrafting Component, manually add this item into the crafting pattern";
-<mekanism:energycube>.addTooltip(format.red(text));
-<mekanism:basicblock2:3>.addTooltip(format.red(text));
-<mekanism:basicblock2:4>.addTooltip(format.red(text));
-<mekanism:transmitter>.addTooltip(format.red(text));
-<mekanism:transmitter:1>.addTooltip(format.red(text));
-<mekanism:transmitter:2>.addTooltip(format.red(text));
-<mekanism:transmitter:3>.addTooltip(format.red(text));
-<mekanism:transmitter:4>.addTooltip(format.red(text));
-<mekanism:transmitter:5>.addTooltip(format.red(text));
-<mekanism:transmitter:6>.addTooltip(format.red(text));
-<mekanism:gastank>.addTooltip(format.red(text));
-<mekanism:basicblock:6>.addTooltip(format.red(text));
-<mekanism:machineblock2:11>.addTooltip(format.red(text));
+var supremarmor = [<mysticalagriculture:supremium_helmet>,<mysticalagriculture:supremium_chestplate>,<mysticalagriculture:supremium_leggings>,<mysticalagriculture:supremium_boots>] as IItemStack[];
+for armor in supremarmor {
+  armor.addTooltip(format.red("Flight Disabled"));
+}
+
+var beneathores = [<mekanism:oreblock>,<nuclearcraft:ore:3>,<nuclearcraft:ore:5>,<nuclearcraft:ore:6>,<nuclearcraft:ore:7>,<immersiveengineering:ore:5>] as IItemStack[];
+for ores in beneathores {
+	ores.addTooltip(format.darkPurple("Only found in the Beneath"));
+}
+
+var mektooltiptext = ["If used in an AE2 Autocrafting Pattern, manually add this item into the crafting pattern, else it will not work.","Do not place with a Builder's Wand, will revert to Basic version."] as string[];
+var mektooltipitems = [<mekanism:energycube>,<mekanism:basicblock2:3>,<mekanism:basicblock2:4>,<mekanism:transmitter:*>,<mekanism:gastank>,<mekanism:basicblock:6>,<mekanism:machineblock2:11>] as IItemStack[];
+for items in mektooltipitems {
+	for text in mektooltiptext {
+		items.addTooltip(format.red(text));
+	}
+}
+val mekfactorymetas = [5,6,7] as int[];
+for metas in mekfactorymetas {
+	itemUtils.getItem("mekanism:machineblock",metas).addTooltip(format.red("Do not place with a Builder's Wand, will transform into a Smelting Factory"));
+}
 
 
 print("--- Tooltip.zs initialized ---");	

--- a/Client/overrides/scripts/Tooltip.zs
+++ b/Client/overrides/scripts/Tooltip.zs
@@ -10,7 +10,6 @@ print("--- loading Tooltip.zs ---");
 <minecraft:nether_star>.addTooltip(format.gold("Earth below us, Drifting falling"));
 <ebwizardry:crystal_block>.addTooltip(format.gold("Can be used to ward off Nether Portal Corruption"));
 <wings:fairy_dust>.addTooltip(format.gold("Can be used to transmute certain metals. This dust radiates primal magic energy"));
-<mekanismgenerators:reactor>.addTooltip(format.gold("Only requires one Chemical Reactor for recipe"));
 <ftbquests:lootcrate>.withTag({type: "cultist"}).addTooltip(format.darkRed("Step one... Dress to impress!"));
 <ftbquests:lootcrate>.withTag({type: "extraterrestrial_cache"}).addTooltip(format.gold("Keep your eyes on the stars, and your feet on the ground. -Theodore Roosevelt"));
 <mysticalagriculture:diamond_seeds>.addTooltip(format.darkPurple("Do all Mystical Agriculture quests to unlock"));

--- a/Client/overrides/scripts/Tooltip.zs
+++ b/Client/overrides/scripts/Tooltip.zs
@@ -32,6 +32,8 @@ print("--- loading Tooltip.zs ---");
 <thaumicaugmentation:impulse_cannon_augment>.addTooltip(format.lightPurple("Damage Amplified to 20x"));
 <appliedenergistics2:sky_compass>.addTooltip(format.red("Only Spawns in The Beneath and on The Moon"));
 <lootgames:ms_activator>.addTooltip(format.red("WARNING: DO NOT PLACE IN YOUR BASE"));
+<erebus:materials:1>.addTooltip(format.gold("The Tinkers' Construct material for this item has been buffed massively."));
+<theaurorian:auroriansteel>.addTooltip(format.gold("The Tinkers' Construct material for this item has been buffed massively."));
 
 var supremarmor = [<mysticalagriculture:supremium_helmet>,<mysticalagriculture:supremium_chestplate>,<mysticalagriculture:supremium_leggings>,<mysticalagriculture:supremium_boots>] as IItemStack[];
 for armor in supremarmor {


### PR DESCRIPTION
Change Beneath and Supremium Armor tooltips to Array+Loop and make it "Flight Disabled" instead of "Disabled Flight".
Adjust grammar of Inventory Cake tooltip.
Change Mekanism AE Autocrafting tooltip to Array+Loop, and add extra details.
Add Mekanism Builder's Wand tooltip(s), Basic Version warning for usual Mek devices, and Smelting Factory conversion warning for Factories.