### PR TITLE
Make Erebus and Aurorian not overlap in Warp Controller

### DIFF
--- a/Client/overrides/config/advRocketry/planetDefs.xml
+++ b/Client/overrides/config/advRocketry/planetDefs.xml
@@ -19,11 +19,11 @@
         </planet>
 		<planet name="§c§lErebus" DIMID="66" customIcon="IceWorld">
             <skyColor>0,0,0</skyColor>
-			<atmosphereDensity>150</atmosphereDensity>
+			<atmosphereDensity>180</atmosphereDensity>
 			<gravitationalMultiplier>38</gravitationalMultiplier>
-			<orbitalDistance>130</orbitalDistance>
+			<orbitalDistance>70</orbitalDistance>
 			<isKnown>True</isKnown>
-			<rotationalPeriod>1400000</rotationalPeriod>
+			<rotationalPeriod>900000</rotationalPeriod>
         </planet>
 		<planet name="§b§lAurorian" DIMID="424" customIcon="GasGiantBlue">
             <skyColor>0,0,0</skyColor>


### PR DESCRIPTION
Image of locations ingame
![image](https://user-images.githubusercontent.com/63694982/132744794-e3e142f0-8c41-4297-97b1-6bda701b5281.png)

Bottommost left planet is Erebus