### PR TITLE
Add recipe for Erebus' Advanced Homing Beecon

### DIFF
--- a/Client/overrides/scripts/MiscCrafting.zs
+++ b/Client/overrides/scripts/MiscCrafting.zs
@@ -1,0 +1,7 @@
+#MC Eternal Scripts
+
+print("--- loading MiscCrafting.zs ---");
+
+recipes.addShaped(<erebus:homing_beecon_advanced>, [[<erebus:materials:41>],[<erebus:homing_beecon>],[<mekanism:teleportationcore>]]);
+
+print("--- MiscCrafting.zs initialized ---");	


### PR DESCRIPTION
Item was never implemented into loot, and makes a quest in the Erebus tab impossible as a result.
Image of recipe
![image](https://user-images.githubusercontent.com/63694982/132749304-c317e5e1-f10d-421a-871d-23662920c516.png)