### PR TITLE
Matrix Enchanting + Dungeonsmod Traveller quests

### DIFF
--- a/Client/overrides/config/ftbquests/classic/chapters/189d88b6/92ca1bd3.snbt
+++ b/Client/overrides/config/ftbquests/classic/chapters/189d88b6/92ca1bd3.snbt
@@ -1,0 +1,22 @@
+{
+	title: "Meet the Traveler",
+	x: -11.0d,
+	y: -5.5d,
+	description: "The Traveler can be summoned by lighting a &9Block of Coal&r &7on &cfire§r&7, they sell maps to various Bosses from Dungeons Mod.",
+	dependencies: [
+		"d22a6b71"
+	],
+	tasks: [{
+		uid: "4cba2945",
+		type: "advancement",
+		title: "Trade Sugar to the Traveler",
+		icon: "dungeonsmod:back_pergamine",
+		advancement: "dungeonsmod:dungeons/root",
+		criterion: ""
+	}],
+	rewards: [{
+		uid: "e3d1dc6b",
+		type: "ftbmoney:money",
+		ftb_money: 50L
+	}]
+}

--- a/Client/overrides/config/ftbquests/classic/chapters/189d88b6/9e3a30c7.snbt
+++ b/Client/overrides/config/ftbquests/classic/chapters/189d88b6/9e3a30c7.snbt
@@ -1,0 +1,44 @@
+{
+	title: "Matrix Enchanting",
+	icon: "minecraft:enchanting_table",
+	x: -11.5d,
+	y: -4.0d,
+	description: "Enchanting might look a little different, here's a really detailed explanation! *Read description*",
+	text: [
+		"This modpack has §6Matrix Enchanting§r from &bQuark§r enabled, it's essentially a system that turns enchanting from total randomness into a little puzzle.",
+		"",
+		"You spend &aXP levels&r and some &9Lapis&r to roll pieces for the Puzzle in the middle, more &5Enchanting Power&r from blocks like §6Bookshelves§r allows you to get more rolls.",
+		"",
+		"You combine pieces with the same &dEnchantment&r by selecting one piece and clicking another, this is how you get higher Levels of &dEnchantments&r.",
+		"",
+		"The ultimate goal is to fit the &dEnchantments&r you want to get into the Puzzle grid in the center, it may not be best to combine Enchant pieces as soon as you get them, since other shapes may work better with what you end up rolling.",
+		"",
+		"Additionally, if you remove the item from the Table while Enchanting, it will retain any Matrix Enchanting-related information, so you can use it a bit more before finalizing, or wait until you have more §5Enchanting Power§r.",
+		"",
+		"Lastly, placing Quark's various colors of &9Candles&r near the Table will improve the chances of getting &dcertain Enchantments&r, based on the &9Candle's&r color!",
+		"",
+		"&8&lBy not reading this, you are claiming responsibility for any damages caused by misunderstanding, Adam Co. is not liable to pay for any damages."
+	],
+	dependencies: [
+		"d22a6b71"
+	],
+	tasks: [{
+		uid: "9234e61d",
+		type: "checkmark",
+		title: "§8Click to Accept the Terms and Conditions"
+	},
+	{
+		uid: "762c0396",
+		type: "observation",
+		title: "§d§lLook at an Enchanting Table, Open your Questbook!",
+		icon: "minecraft:enchanting_table",
+		match_type: "block_id",
+		match: "minecraft:enchanting_table",
+		timer: 0L
+	}],
+	rewards: [{
+		uid: "fb43a87e",
+		type: "ftbmoney:money",
+		ftb_money: 75L
+	}]
+}

--- a/Client/overrides/config/ftbquests/classic/chapters/189d88b6/9f78a78f.snbt
+++ b/Client/overrides/config/ftbquests/classic/chapters/189d88b6/9f78a78f.snbt
@@ -4,7 +4,7 @@
 	y: -6.0d,
 	description: "&oFind and slay the King and his knights",
 	dependencies: [
-		"d22a6b71"
+		"92ca1bd3"
 	],
 	size: 0.9d,
 	optional: true,

--- a/Client/overrides/config/ftbquests/classic/chapters/189d88b6/b1b8d431.snbt
+++ b/Client/overrides/config/ftbquests/classic/chapters/189d88b6/b1b8d431.snbt
@@ -26,7 +26,8 @@
 				}
 			},
 			Damage: 1s
-		}]
+		}],
+		ignore_nbt: 1b
 	},
 	{
 		uid: "8c17ba04",

--- a/Client/overrides/config/ftbquests/classic/chapters/189d88b6/bd0b2e95.snbt
+++ b/Client/overrides/config/ftbquests/classic/chapters/189d88b6/bd0b2e95.snbt
@@ -4,7 +4,7 @@
 	y: -5.0d,
 	description: "&oFind and slay the Deserted &k0",
 	dependencies: [
-		"d22a6b71"
+		"92ca1bd3"
 	],
 	size: 0.9d,
 	optional: true,

--- a/Client/overrides/config/ftbquests/normal/chapters/189d88b6/92ca1bd3.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/189d88b6/92ca1bd3.snbt
@@ -1,0 +1,22 @@
+{
+	title: "Meet the Traveler",
+	x: -11.0d,
+	y: -5.5d,
+	description: "The Traveler can be summoned by lighting a &9Block of Coal&r &7on &cfire§r&7, they sell maps to various Bosses from Dungeons Mod.",
+	dependencies: [
+		"d22a6b71"
+	],
+	tasks: [{
+		uid: "4cba2945",
+		type: "advancement",
+		title: "Trade Sugar to the Traveler",
+		icon: "dungeonsmod:back_pergamine",
+		advancement: "dungeonsmod:dungeons/root",
+		criterion: ""
+	}],
+	rewards: [{
+		uid: "e3d1dc6b",
+		type: "ftbmoney:money",
+		ftb_money: 50L
+	}]
+}

--- a/Client/overrides/config/ftbquests/normal/chapters/189d88b6/9e3a30c7.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/189d88b6/9e3a30c7.snbt
@@ -1,0 +1,44 @@
+{
+	title: "Matrix Enchanting",
+	icon: "minecraft:enchanting_table",
+	x: -11.5d,
+	y: -4.0d,
+	description: "Enchanting might look a little different, here's a really detailed explanation! *Read description*",
+	text: [
+		"This modpack has §6Matrix Enchanting§r from &bQuark§r enabled, it's essentially a system that turns enchanting from total randomness into a little puzzle.",
+		"",
+		"You spend &aXP levels&r and some &9Lapis&r to roll pieces for the Puzzle in the middle, more &5Enchanting Power&r from blocks like §6Bookshelves§r allows you to get more rolls.",
+		"",
+		"You combine pieces with the same &dEnchantment&r by selecting one piece and clicking another, this is how you get higher Levels of &dEnchantments&r.",
+		"",
+		"The ultimate goal is to fit the &dEnchantments&r you want to get into the Puzzle grid in the center, it may not be best to combine Enchant pieces as soon as you get them, since other shapes may work better with what you end up rolling.",
+		"",
+		"Additionally, if you remove the item from the Table while Enchanting, it will retain any Matrix Enchanting-related information, so you can use it a bit more before finalizing, or wait until you have more §5Enchanting Power§r.",
+		"",
+		"Lastly, placing Quark's various colors of &9Candles&r near the Table will improve the chances of getting &dcertain Enchantments&r, based on the &9Candle's&r color!",
+		"",
+		"&8&lBy not reading this, you are claiming responsibility for any damages caused by misunderstanding, Adam Co. is not liable to pay for any damages."
+	],
+	dependencies: [
+		"d22a6b71"
+	],
+	tasks: [{
+		uid: "9234e61d",
+		type: "checkmark",
+		title: "§8Click to Accept the Terms and Conditions"
+	},
+	{
+		uid: "762c0396",
+		type: "observation",
+		title: "§d§lLook at an Enchanting Table, Open your Questbook!",
+		icon: "minecraft:enchanting_table",
+		match_type: "block_id",
+		match: "minecraft:enchanting_table",
+		timer: 0L
+	}],
+	rewards: [{
+		uid: "fb43a87e",
+		type: "ftbmoney:money",
+		ftb_money: 75L
+	}]
+}

--- a/Client/overrides/config/ftbquests/normal/chapters/189d88b6/9f78a78f.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/189d88b6/9f78a78f.snbt
@@ -4,7 +4,7 @@
 	y: -6.0d,
 	description: "&oFind and slay the King and his knights",
 	dependencies: [
-		"d22a6b71"
+		"92ca1bd3"
 	],
 	size: 0.9d,
 	optional: true,

--- a/Client/overrides/config/ftbquests/normal/chapters/189d88b6/b1b8d431.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/189d88b6/b1b8d431.snbt
@@ -26,7 +26,8 @@
 				}
 			},
 			Damage: 1s
-		}]
+		}],
+		ignore_nbt: 1b
 	},
 	{
 		uid: "8c17ba04",

--- a/Client/overrides/config/ftbquests/normal/chapters/189d88b6/bd0b2e95.snbt
+++ b/Client/overrides/config/ftbquests/normal/chapters/189d88b6/bd0b2e95.snbt
@@ -4,7 +4,7 @@
 	y: -5.0d,
 	description: "&oFind and slay the Deserted &k0",
 	dependencies: [
-		"d22a6b71"
+		"92ca1bd3"
 	],
 	size: 0.9d,
 	optional: true,


### PR DESCRIPTION
Add quest with a monolith of text about Matrix Enchanting.
Add Dungeonsmod Traveller quest, tied to the Advancement, tells you how to summon it.
Change Dungeonsmod quests in Intro to depend on Traveler quest.

Image of quests and changes:
![image](https://user-images.githubusercontent.com/63694982/132802084-9dd35a7f-6e28-4a1a-8a0e-7ce33623d1d1.png)

Image of Traveler quest subtitle:
![image](https://user-images.githubusercontent.com/63694982/132802164-651e4eda-4b3c-46e6-ab31-eb40187f6897.png)

<details>
   <summary>Image of The Monolith of Text:</summary>

![image](https://user-images.githubusercontent.com/63694982/132802187-4a6e623e-e80f-4af8-963a-ea9c4c835c23.png)

</details>