### PR TITLE
Blacklist lots of Potion effects from Pharos Beacon

### DIFF
--- a/Client/overrides/config/cyclicmagic.cfg
+++ b/Client/overrides/config/cyclicmagic.cfg
@@ -1328,6 +1328,52 @@ modpacks {
         minecraft:instant_damage
         minecraft:wither
         minecraft:poison
+        minecraft:nausea
+		minecraft:absorption
+		minecraft:levitation
+		mod_lavacow:corrosive
+		mod_lavacow:soiled
+		mod_lavacow:infestation
+		randomthings:collapse
+		potioncore:love
+		potioncore:flight
+		potioncore:recoil
+		potioncore:burst
+		potioncore:teleport
+		potioncore:teleport_spawn
+		potioncore:teleport_surface
+		potioncore:vulnerable
+		potioncore:weight
+		potioncore:cure
+		potioncore:disorganization
+		potioncore:drowning
+		potioncore:perplexity
+		potioncore:rust
+		potioncore:vulnerability
+		potioncore:explosion
+		potioncore:fire
+		potioncore:lightning
+		potioncore:chance
+		potioncore:inversion
+		potioncore:weight
+		potioncore:launch
+		potioncore:dispel
+		potioncore:revival
+		potioncore:curse
+		potioncore:burst
+		cyclicmagic:potion.ender
+		cyclicmagic:potion.snow
+		cyclicmagic:potion.butterfingers
+		cyclicmagic:potion.bounce
+		cyclicmagic:potion.frostwalker
+		extrautils2:effect.xu2.doom
+		extrautils2:effect.xu2.fizzy.lifting
+		extrautils2:effect.xu2.gravity
+		extrautils2:effect.xu2.greek.fire
+		extrautils2:effect.xu2.love
+		extrautils2:effect.xu2.purging
+		extrautils2:effect.xu2.relapse
+		extrautils2:effect.xu2.second.chance
      >
 
     # Set to make Pharos Beacon free and perpetual, so it will not consume potions.  However if this set false, once it reads an effect from a potion, you must break and replace the beacon to wipe out its current effect.  [default: true]


### PR DESCRIPTION
these potion effects could potentially be very dum in Pharos Beacon :v
I hope Artifacts doesn't generate fully wild potions :C it doesn't seem to thankfully, but idk for sure