### PR TITLE
Buff Thaumcraft Bosses into Champions

### DIFF
--- a/Client/overrides/config/champions.cfg
+++ b/Client/overrides/config/champions.cfg
@@ -19,20 +19,20 @@ general {
         Fear
         Lord
         Burning Legion
-	Draconic
-	Gregorious
-	Avaricious
+		Draconic
+		Gregorious
+		Avaricious
      >
 
     # Additional names that will be added to the pool of names given to champions
     S:"Additional Champion Names" <
-	Quack
+		Quack
         Goat
         Emper
         Bread-Tea
         Corjaantje
         Kraken
-	Sparkly
+		Sparkly
      >
 
     # The range an active beacon will prevent champion spawns, 0 to disable
@@ -58,7 +58,14 @@ general {
         erebus:erebus.tarantula_mini_boss;2
         erebus:erebus.antlion_boss;3
         atum:pharaoh;4
-	illagers_plus:illager_king;3
+		illagers_plus:illager_king;3
+        thaumicaugmentation:eldritch_golem;2
+        thaumicaugmentation:eldritch_warden;2
+        thaumcraft:cultistportalgreater;1
+        thaumcraft:cultistleader;1
+        thaumcraft:eldritchwarden;1
+        thaumcraft:eldritchgolem;1
+        thaumcraft:taintaclegiant;2
      >
 
     # Set whether champions can spawn from mob spawners

--- a/Client/overrides/config/champions.cfg
+++ b/Client/overrides/config/champions.cfg
@@ -19,20 +19,20 @@ general {
         Fear
         Lord
         Burning Legion
-		Draconic
-		Gregorious
-		Avaricious
+	Draconic
+	Gregorious
+	Avaricious
      >
 
     # Additional names that will be added to the pool of names given to champions
     S:"Additional Champion Names" <
-		Quack
+	Quack
         Goat
         Emper
         Bread-Tea
         Corjaantje
         Kraken
-		Sparkly
+	Sparkly
      >
 
     # The range an active beacon will prevent champion spawns, 0 to disable
@@ -58,7 +58,7 @@ general {
         erebus:erebus.tarantula_mini_boss;2
         erebus:erebus.antlion_boss;3
         atum:pharaoh;4
-		illagers_plus:illager_king;3
+	illagers_plus:illager_king;3
         thaumicaugmentation:eldritch_golem;2
         thaumicaugmentation:eldritch_warden;2
         thaumcraft:cultistportalgreater;1
@@ -92,7 +92,7 @@ general {
 
     # Sets the loot drops from champions if loot source is set to CONFIG, format is tier;modid:name;metadata;stacksize;enchant(true/false);weight
     S:"Loot Drops" <
-		rats:cheese;5
+	rats:cheese;5
         minecraft:diamond;1
         minecraft:gold_ingot;3
      >

--- a/Client/overrides/config/champions/affixes.json
+++ b/Client/overrides/config/champions/affixes.json
@@ -2,7 +2,7 @@
   {
     "identifier": "vortex",
     "enabled": false,
-    "entityBlacklist": [],
+    "entityBlacklist": ["thaumicaugmentation:eldritch_golem", "thaumicaugmentation:eldritch_warden", "thaumcraft:cultistleader", "thaumcraft:eldritchwarden"],
     "alwaysOnEntity": [],
     "tier": 1
   },
@@ -37,21 +37,21 @@
   {
     "identifier": "reflecting",
     "enabled": true,
-    "entityBlacklist": ["twilightforest:lich"],
+    "entityBlacklist": ["twilightforest:lich", "thaumicaugmentation:eldritch_golem", "thaumicaugmentation:eldritch_warden"],
     "alwaysOnEntity": [],
     "tier": 1
   },
   {
     "identifier": "knockback",
     "enabled": true,
-    "entityBlacklist": ["twilightforest:naga"],
+    "entityBlacklist": ["twilightforest:naga", "thaumcraft:cultistportalgreater"],
     "alwaysOnEntity": [],
     "tier": 1
   },
   {
     "identifier": "jailer",
     "enabled": true,
-    "entityBlacklist": [],
+    "entityBlacklist": ["thaumicaugmentation:eldritch_golem", "thaumicaugmentation:eldritch_warden", "thaumcraft:cultistleader"],
     "alwaysOnEntity": [],
     "tier": 1
   },
@@ -73,7 +73,7 @@
     "identifier": "adaptable",
     "enabled": true,
     "entityBlacklist": ["minecraft:ender_dragon", "minecraft:wither", "twilightforest:naga", "twilightforest:lich", "twilightforest:hydra", "erebus:erebus.crushroom", "erebus:erebus.tarantula_mini_boss", "erebus:erebus.antlion_boss", "atum:pharaoh"],
-    "alwaysOnEntity": [],
+    "alwaysOnEntity": ["thaumcraft:taintaclegiant"],
     "tier": 1
   },
   {
@@ -86,14 +86,14 @@
   {
     "identifier": "hasty",
     "enabled": true,
-    "entityBlacklist": ["minecraft:wither", "minecraft:ender_dragon", "twilightforest:naga", "twilightforest:lich", "twilightforest:minoshroom", "twilightforest:hydra", "twilightforest:snow_queen", "twilightforest:ur_ghast", "erebus:erebus.crushroom", "erebus:erebus.tarantula_mini_boss", "erebus:erebus.antlion_boss", "atum:pharaoh"],
+    "entityBlacklist": ["minecraft:wither", "minecraft:ender_dragon", "twilightforest:naga", "twilightforest:lich", "twilightforest:minoshroom", "twilightforest:hydra", "twilightforest:snow_queen", "twilightforest:ur_ghast", "erebus:erebus.crushroom", "erebus:erebus.tarantula_mini_boss", "erebus:erebus.antlion_boss", "atum:pharaoh", "thaumicaugmentation:eldritch_golem", "thaumicaugmentation:eldritch_warden", "thaumcraft:cultistportalgreater", "thaumcraft:taintaclegiant"],
     "alwaysOnEntity": [],
     "tier": 1
   },
   {
     "identifier": "shielding",
     "enabled": true,
-    "entityBlacklist": ["minecraft:wither", "minecraft:ender_dragon", "twilightforest:naga", "twilightforest:lich", "twilightforest:minoshroom", "twilightforest:hydra", "twilightforest:snow_queen", "twilightforest:ur_ghast", "theaurorian:runestonedungeonkeeper", "theaurorian:spider", "theaurorian:moonqueen", "erebus:erebus.crushroom", "erebus:erebus.tarantula_mini_boss", "erebus:erebus.antlion_boss", "atum:pharaoh"],
+    "entityBlacklist": ["minecraft:wither", "minecraft:ender_dragon", "twilightforest:naga", "twilightforest:lich", "twilightforest:minoshroom", "twilightforest:hydra", "twilightforest:snow_queen", "twilightforest:ur_ghast", "theaurorian:runestonedungeonkeeper", "theaurorian:spider", "theaurorian:moonqueen", "erebus:erebus.crushroom", "erebus:erebus.tarantula_mini_boss", "erebus:erebus.antlion_boss", "atum:pharaoh", "thaumicaugmentation:eldritch_golem", "thaumicaugmentation:eldritch_warden", "thaumcraft:cultistportalgreater", "thaumcraft:cultistleader", "thaumcraft:eldritchwarden", "thaumcraft:eldritchgolem", "thaumcraft:taintaclegiant","fossil:fossil.anu"],
     "alwaysOnEntity": [],
     "tier": 1
   },
@@ -107,7 +107,7 @@
   {
     "identifier": "plagued",
     "enabled": false,
-    "entityBlacklist": [],
+    "entityBlacklist": ["thaumicaugmentation:eldritch_golem", "thaumicaugmentation:eldritch_warden", "thaumcraft:eldritchgolem", "thaumcraft:eldritchwarden"],
     "alwaysOnEntity": [],
     "tier": 1
   }


### PR DESCRIPTION
Forgot about this yesteryday, so here we are.

Thaumic Augmentation bosses are 2-Star, base TC bosses are 1-Star, except Giant Taintacle, which is 2.
Giant Taintacle always has Adapatable affix.

Affix blacklist settings:
Vortex: TAug Construct, TC/TAug Warden, Crimson Praetor
Reflecting: TAug Construct, TAug Warden
Knockback: Greater Crimson Portal
Jailer: TAug Construct, TAug Warden, Crimson Praetor
Hasty: TAug Construct, TAug Warden, Greater Crimson Portal, Giant Taintacle
Shielding: All 6
Plagued: TAug/TC Construct, TAug/TC Warden