### PR TITLE
Blacklist Dragons from Ancient Spellcraft pocket dim

### DIFF
--- a/Client/overrides/config/ice_and_fire.cfg
+++ b/Client/overrides/config/ice_and_fire.cfg
@@ -57,6 +57,7 @@ all {
         -9999
         2000
         1
+        312
      >
 
     # Misc Structures(Cyclops caves, Gorgon temples, etc) cannot spawn in these dimensions' IDs


### PR DESCRIPTION
used to break it apparently, probably shouldn't spawn there anyways, we don't need dragons wrecking your supposed-to-be-safe belongings :v