### PR TITLE
Disable Empowering Presence spell from EBW

### DIFF
--- a/Client/overrides/config/ebwizardry.cfg
+++ b/Client/overrides/config/ebwizardry.cfg
@@ -397,7 +397,7 @@ spells {
     B:"ebwizardry:earthquake"=true
 
     # Grants the caster and nearby allies increased magic damage for 30 seconds.
-    B:"ebwizardry:empowering_presence"=true
+    B:"ebwizardry:empowering_presence"=false
 
     # Traps the target in a sphere of darkness which pulls it helplessly upwards and continually damages it.
     B:"ebwizardry:entrapment"=true


### PR DESCRIPTION
Fundamentally broken :v grants extra spell potency which allows certain spells to be brokenly overpowered as shite.