### PR TITLE
Deny EerieEntities wisp spawns in Erebus

### DIFF
--- a/Client/overrides/config/incontrol/spawn.json
+++ b/Client/overrides/config/incontrol/spawn.json
@@ -153,5 +153,10 @@
 	"healthmultiply": 50,
 	"damagemultiply": 20,
 	"speedmultiply": 1.5
+  },
+  {
+    "dimension": 66,
+    "mob": "eerieentities:wisp",
+    "result": "deny"
   }
 ]


### PR DESCRIPTION
yeets lag from excessive wisp spawns in erebus.
Should work according to Defend#4415 in the discord