### PR TITLE
Increase rarity of Fairy Dust a good bit

### DIFF
--- a/Client/overrides/config/wings/ores.cfg
+++ b/Client/overrides/config/wings/ores.cfg
@@ -16,13 +16,13 @@ amethyst {
 fairy_dust {
     # Min: 0
     # Max: 128
-    I:count=10
+    I:count=3
     I:maxHeight=64
     I:minHeight=0
 
     # Min: 8
     # Max: 32
-    I:size=9
+    I:size=4
 }
 
 


### PR DESCRIPTION
according to Adam, it was supposed to be rare since the initial 1.4 release, but he forgot to do it, it's kind of literally everywhere, and isn't crazy useful, so turning it down a bit is probably a fine idea.