### PR TITLE
nerf alkahestry

### DIFF
--- a/Client/overrides/config/xreliquary/alkahestry_overrides/charging/crystal_shard.json
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/charging/crystal_shard.json
@@ -1,0 +1,9 @@
+{
+    "type": "xreliquary:alkahestry_charging",
+    "charge": 2,
+    "ingredients": [
+        {
+            "item": "biomesoplenty:crystal_shard"
+        }
+    ]
+}

--- a/Client/overrides/config/xreliquary/alkahestry_overrides/charging/glowstone.disabled
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/charging/glowstone.disabled
@@ -1,0 +1,9 @@
+{
+    "type": "xreliquary:alkahestry_charging",
+    "charge": 4,
+    "ingredients": [
+        {
+            "item": "minecraft:glowstone"
+        }
+    ]
+}

--- a/Client/overrides/config/xreliquary/alkahestry_overrides/charging/glowstone_dust.disabled
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/charging/glowstone_dust.disabled
@@ -1,0 +1,9 @@
+{
+    "type": "xreliquary:alkahestry_charging",
+    "charge": 1,
+    "ingredients": [
+        {
+            "item": "minecraft:glowstone_dust"
+        }
+    ]
+}

--- a/Client/overrides/config/xreliquary/alkahestry_overrides/charging/redstone.disabled
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/charging/redstone.disabled
@@ -1,0 +1,9 @@
+{
+    "type": "xreliquary:alkahestry_charging",
+    "charge": 1,
+    "ingredients": [
+        {
+            "item": "minecraft:redstone"
+        }
+    ]
+}

--- a/Client/overrides/config/xreliquary/alkahestry_overrides/charging/redstone_block.disabled
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/charging/redstone_block.disabled
@@ -1,0 +1,9 @@
+{
+    "type": "xreliquary:alkahestry_charging",
+    "charge": 9,
+    "ingredients": [
+        {
+            "item": "minecraft:redstone_block"
+        }
+    ]
+}

--- a/Client/overrides/config/xreliquary/alkahestry_overrides/charging/tiberium.json
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/charging/tiberium.json
@@ -1,0 +1,9 @@
+{
+    "type": "xreliquary:alkahestry_charging",
+    "charge": 1,
+    "ingredients": [
+        {
+            "item": "taiga:tiberium_crystal"
+        }
+    ]
+}

--- a/Client/overrides/config/xreliquary/alkahestry_overrides/charging/world_thread.json
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/charging/world_thread.json
@@ -1,0 +1,9 @@
+{
+    "type": "xreliquary:alkahestry_charging",
+    "charge": 50,
+    "ingredients": [
+        {
+            "item": "dimdoors:world_thread"
+        }
+    ]
+}

--- a/Client/overrides/config/xreliquary/alkahestry_overrides/crafting/nether_star.disabled
+++ b/Client/overrides/config/xreliquary/alkahestry_overrides/crafting/nether_star.disabled
@@ -1,0 +1,10 @@
+{
+    "type": "xreliquary:alkahestry_crafting",
+    "charge": 1000,
+    "ingredients": [
+        {
+            "item": "minecraft:nether_star"
+        }
+    ],
+    "result_count": 2
+}


### PR DESCRIPTION
evil:tm:
redstone and glowstone can no longer be used, instead tiberium, bop celestial crystal shards, and dimdoors world threads are used.
oh and you can't copy netherstars with it anymore