### PR TITLE
Living Armour Training Bracelet should depend on SotCS ritual

### DIFF
--- a/Client/overrides/config/ftbquests/classic/chapters/bec752d7/e4ad7b26.snbt
+++ b/Client/overrides/config/ftbquests/classic/chapters/bec752d7/e4ad7b26.snbt
@@ -10,7 +10,8 @@
 		"Afterwards, simply carry the Bracelet(s) with you, and only the &6Upgrade(s)&7 they have set will be Trained."
 	],
 	dependencies: [
-		"3736ae94"
+		"3736ae94",
+		"c50f41bc"
 	],
 	tasks: [{
 		uid: "0ccacefe",


### PR DESCRIPTION
i forgot for a minute that you need an upgrade tome to tune the bracelet :|