### PR TITLE
some eeny fixes for 1.6.3.2

### DIFF
--- a/Client/overrides/scripts/MiscCrafting.zs
+++ b/Client/overrides/scripts/MiscCrafting.zs
@@ -185,4 +185,30 @@ for thing in nonFunctionalExtraCellsThings {
 	}
 }
 
+
+
+//Space Dimension Flight-permitting Items
+
+//Staff of Gaea
+recipes.addShaped("mce_erebus_staff_for_flying", <erebus:portal_activator>, [
+	[null, <erebus:tarantula_egg>.reuse(), <erebus:materials:38>],
+	[<ore:ingotDyonite>, <erebus:wand_of_animation>, <erebus:antlion_egg>.reuse()],
+	[<erebus:materials:39>, <ore:ingotDyonite>]
+]);
+
+//Scarab
+recipes.addShaped("mce_atum_scarab_for_flying", <atum:scarab>, [
+	[null, skyScarabCrest],
+	[<atum:idol_of_labor>.reuse(), <atum:crunchy_golden_scarab>, <atum:heart_of_ra>.reuse()],
+	[null, <minecraft:elytra>]
+]);
+
+//"Aurorian Sky Spirit"
+recipes.addShaped("mce_aurorian_spirit_for_flying", <theaurorian:crystallinesprite>, [
+	[<enderio:block_holier_fog>, <theaurorian:trophykeeper>.reuse(), <enderio:block_holier_fog>],
+	[<theaurorian:bepsi>, <theaurorian:trophyspider>.reuse(), <theaurorian:bepsi>],
+	[<enderio:block_holier_fog>, <theaurorian:trophymoonqueen>.reuse(), <enderio:block_holier_fog>]
+]);
+
+
 print("--- MiscCrafting.zs initialized ---");	

--- a/Client/overrides/scripts/challenge/misc.zs
+++ b/Client/overrides/scripts/challenge/misc.zs
@@ -529,6 +529,8 @@ events.onEntityJoinWorld(function(event as crafttweaker.event.EntityJoinWorldEve
 
 //apply data to player that kills ender dragon
 // using advancement allows collaborating players to both get credit, i think
+// COMMENTED OUT INTENTIONALLY, does not work for whatever reason. the advancement event handler can see the flag, but the tick event can't, ever? what the shit.
+/*
 events.onPlayerAdvancement(function(event as crafttweaker.event.PlayerAdvancementEvent){
 	if(event.id == "minecraft:end/kill_dragon" && !(event.player.tags has "killedEnderDragon")){
 		event.player.addTag("killedEnderDragon");
@@ -555,6 +557,7 @@ events.onPlayerTick(function(event as crafttweaker.event.PlayerTickEvent){
 		}
 	}
 });
+*/
 
 
 //Tooltips


### PR DESCRIPTION
i accidentally removed the space dim flight item recipes while refactoring scripts for 1.6.3, whoops.
challenge mode end restriction thing is broken because of crafttweaker nonsense, so it doesn't exist now.